### PR TITLE
Add translations for 30 languages and convert to XLIFF 1.2

### DIFF
--- a/Resources/Private/Language/af.locallang.xlf
+++ b/Resources/Private/Language/af.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="af" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Sluit sinkronisasiemodule</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Boodskap vir gebruikers in geval van aktiewe slot</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/af.locallang_mod.xlf
+++ b/Resources/Private/Language/af.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="af" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/af.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/af.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="af" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>'n Module vir die sinkronisering van inhoud vanaf 'n produksiestelsel na 'n enkele of veelvuldige teikensstelsels.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Skep nuwe Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Skep Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Forseer 'n volledige sinkronisasie. 'n Volledige sinkronisasie van hierdie item word begin selfs al is 'n inkrementele sinkronisasie moontlik. Dit moet indien moontlik vermy word.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Verwyder verouderde rekords op die teikenstelsel. Enige rekords wat as verborge of verwyder gemerk is, of waar die rekord eindtyd 'n datum in die verlede is, sal op die teikenstelsel verwyder word.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Tabel-sinkronisasiestatus</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabel</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Laaste sinkronisasietyd</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Laaste sinkronisasietipe</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Laaste sinkronisasiegebruiker</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>volledig</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>inkrementeel</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Sync-lys</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Wagtende Sync's</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} lêer(s) wag vir sinkronisasie {size}. Oudste lêer vanaf {oldestFile} en dus {minutes} minute oud.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Lêer</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Grootte</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Item</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Aksie</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Sync-teiken:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Teiken '{target}' gedeaktiveer vir sinkronisasie.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Teiken '{target}' geaktiveer vir sinkronisasie.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Sluit sync-module</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Ontsluit sync-module</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Sluit sync-teiken: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Ontsluit sync-teiken: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Slegs geselekteerde bladsy</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Geselekteerde bladsy en alle {pages} subbladsy's</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(waarvan {deleted} verwyder is, {noaccess} geblokkeer is, en {falses} die verkeerde bladsy-tipe het)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} subbladsy's met {deleted} verwyder en {noaccess} ontoeganklik)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Bladsy: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Daar is beperkte subgebiede wat van sinkronisasie uitgesluit is.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekursie</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Voeg by sync-lys</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Stel rekursie-diepte</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Teiken '{target}' gesein vir nuwe sinkronisasie.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Teiken '{target}' kon nie ingelig word weens 'n fout nie.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Sein van '{target}' teiken oorgeslaan. Onbekende kennisgewing-tipe: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Sein van '{target}' teiken oorgeslaan weens gedeaktiveerde kennisgewing.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Sein van '{target}' teiken oorgeslaan weens ongeldige konteks. Toegelate kontekste: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabel '{table}' oorgeslaan - geen veranderinge sedert laaste sinkronisasie nie.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sync van Assets begin</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sinkronisasie begin.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sinkronisasie begin - behoort binne die volgende 15 minute verwerk te word.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Tabelstatus opgedateer.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number} hook-URL-lêers geskep</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Geen data gestort vir verdere verwerking nie. Die geselekteerde sinkronisasieproses het geen data gelewer om na die teikenstelsel te sinkroniseer nie.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Stelsel '{target}' is gesluit, dus word geen url-lêer geskep nie.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Volgende tabelle het verander, kontak asseblief jou TYPO3-administrateur:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Stelsel '{system} is gesluit dus word geen stort-lêer daarvoor geskep nie.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Selekteer asseblief 'n bladsy uit die bladsyboom.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Kon nie rekord laai vir geselekteerde bladsy nie: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Die bladsy-tipe mag nie gesinkroniseer word nie.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Tabelstatus-lêer is nie skryfbaar nie.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Daar is geen bladsy's gemerk vir sinkronisasie nie.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Daar is reeds 'n sinkronisasie-voorbereiding aan die gang. Probeer asseblief oor ongeveer 5 minute weer.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zip-lêer vir {file} kon nie geskep word nie.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Lêer {file} kon nie na {target} geskuif word nie.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Selekteer asseblief hoe die bladsy gemerk moet word.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Die bladsy is reeds gemerk vir sinkronisasie</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM-tabelle soos {tableName} word nie meer ondersteun nie.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL het korrupte inskrywings. (Inskrywings met uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>klaar</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Hierdie taak kan 'n bietjie tyd neem, wees asseblief geduldig.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Nuus</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend-gebruikers en groepe</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend-groepe</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Scheduler-take</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirects</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Tabelstatus</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Enkele bladsy's met inhoud</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/af.locallang_scheduler.xlf
+++ b/Resources/Private/Language/af.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="af" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Sync-invoer</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Taak om sinchronisasies in te voer</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Pad waar die sinchronisasielêers gestoor word.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Pad waar die URL-lêers om uit te voer gestoor word.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ar.locallang.xlf
+++ b/Resources/Private/Language/ar.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ar" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>قفل وحدة المزامنة</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>رسالة للمستخدمين في حالة القفل النشط</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ar.locallang_mod.xlf
+++ b/Resources/Private/Language/ar.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ar" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/ar.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/ar.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ar" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>وحدة لمزامنة المحتوى من نظام الإنتاج إلى نظام واحد أو أنظمة متعددة مستهدفة.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>إنشاء Sync جديد</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>إنشاء Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>فرض مزامنة كاملة. يتم بدء مزامنة كاملة لهذا العنصر حتى لو كانت المزامنة التدريجية ممكنة. يجب تجنب ذلك إن أمكن.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>حذف السجلات القديمة على النظام المستهدف. سيتم حذف أي سجلات محددة كمخفية أو محذوفة، أو حيث يكون وقت انتهاء السجل تاريخًا في الماضي، على النظام المستهدف.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>حالة مزامنة الجدول</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>الجدول</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>وقت آخر مزامنة</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>نوع آخر مزامنة</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>مستخدم آخر مزامنة</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>كاملة</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>تدريجية</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>قائمة Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Sync في الانتظار</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} ملف (ملفات) في انتظار المزامنة {size}. أقدم ملف من {oldestFile} وبالتالي عمره {minutes} دقيقة.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>الملف</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>الحجم</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>العنصر</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>الإجراء</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>هدف Sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>تم تعطيل الهدف '{target}' للمزامنة.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>تم تفعيل الهدف '{target}' للمزامنة.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>قفل وحدة sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>فتح وحدة sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>قفل هدف sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>فتح هدف sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>الصفحة المحددة فقط</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>الصفحة المحددة وجميع {pages} صفحة فرعية</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(منها {deleted} محذوفة، و {noaccess} محظورة، و {falses} لها نوع صفحة خاطئ)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} صفحة فرعية مع {deleted} محذوفة و {noaccess} غير قابلة للوصول)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>الصفحة: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>توجد مناطق فرعية مقيدة مستبعدة من المزامنة.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>التكرار</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>إضافة إلى قائمة sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>تعيين عمق التكرار</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>تم إشعار الهدف '{target}' بمزامنة جديدة.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>تعذر إشعار الهدف '{target}' بسبب خطأ.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>تم تخطي إشعار الهدف '{target}'. نوع الإشعار غير معروف: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>تم تخطي إشعار الهدف '{target}' بسبب تعطيل الإشعار.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>تم تخطي إشعار الهدف '{target}' بسبب سياق غير صالح. السياقات المسموحة: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>تم تخطي الجدول '{table}' - لا توجد تغييرات منذ آخر مزامنة.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>تم بدء مزامنة Assets</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>تم بدء المزامنة.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>بدأت المزامنة - يجب معالجتها خلال الـ 15 دقيقة القادمة.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>تم تحديث حالة الجدول.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>تم إنشاء {number} ملف URL لـ hook</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>لم يتم تفريغ بيانات لمزيد من المعالجة. لم تنتج عملية المزامنة المحددة أي بيانات لمزامنتها مع النظام المستهدف.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>النظام '{target}' مقفل، لذا لن يتم إنشاء ملف url.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>تم تغيير الجداول التالية، يرجى الاتصال بمسؤول TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>النظام '{system} مقفل لذا لن يتم إنشاء ملف تفريغ له.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>يرجى تحديد صفحة من شجرة الصفحات.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>تعذر تحميل سجل الصفحة المحددة: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>يجب عدم مزامنة نوع الصفحة.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>ملف حالة الجدول غير قابل للكتابة.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>لا توجد صفحات محددة للمزامنة.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>يوجد بالفعل إعداد مزامنة قيد التقدم. يرجى المحاولة مرة أخرى خلال حوالي 5 دقائق.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>تعذر إنشاء ملف Zip لـ {file}.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>تعذر نقل الملف {file} إلى {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>يرجى تحديد كيفية تحديد الصفحة.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>تم تحديد الصفحة بالفعل للمزامنة</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>جداول MM مثل {tableName} لم تعد مدعومة.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL يحتوي على إدخالات تالفة. (إدخالات مع uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>تم</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>قد تستغرق هذه المهمة بعض الوقت، يرجى التحلي بالصبر.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>الأخبار</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: مستخدمو ومجموعات Backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: مجموعات Frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: مهام Scheduler</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirects</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>حالة الجدول</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: صفحات مفردة مع محتوى</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ar.locallang_scheduler.xlf
+++ b/Resources/Private/Language/ar.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ar" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>استيراد المزامنة</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>مهمة لاستيراد المزامنات</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>المسار الذي يتم فيه تخزين ملفات المزامنة.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>المسار الذي يتم فيه تخزين ملفات الروابط للتنفيذ.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ca.locallang.xlf
+++ b/Resources/Private/Language/ca.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ca" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Bloquejar mòdul de sincronització</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Missatge per als usuaris en cas de bloqueig actiu</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ca.locallang_mod.xlf
+++ b/Resources/Private/Language/ca.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ca" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/ca.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/ca.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ca" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Un mòdul per sincronitzar contingut d'un sistema de producció a un o múltiples sistemes destinació.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Crear nou Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Crear Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Forçar una sincronització completa. S'inicia una sincronització completa d'aquest element fins i tot si és possible una sincronització incremental. Això s'ha d'evitar si és possible.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Suprimeix registres obsolets al sistema destinació. Qualsevol registre que estigui marcat com a ocult o eliminat, o on l'hora final del registre sigui una data del passat, s'eliminarà al sistema destinació.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Estat de sincronització de taula</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Taula</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Hora de l'última sincronització</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Tipus de l'última sincronització</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Usuari de l'última sincronització</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>completa</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>incremental</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Llista de Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Syncs en espera</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} fitxer(s) esperant sincronització {size}. Fitxer més antic de {oldestFile} i per tant de {minutes} minuts d'antiguitat.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Fitxer</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Mida</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Element</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Acció</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Destinació de Sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Destinació '{target}' desactivada per a sincronització.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Destinació '{target}' activada per a sincronització.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Bloquejar mòdul de sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Desbloquejar mòdul de sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Bloquejar destinació de sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Desbloquejar destinació de sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Només la pàgina seleccionada</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Pàgina seleccionada i totes les {pages} subpàgines</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(de les quals {deleted} estan eliminades, {noaccess} estan bloquejades i {falses} tenen el tipus de pàgina incorrecte)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} subpàgines amb {deleted} eliminades i {noaccess} inaccessibles)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Pàgina: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Hi ha subàrees restringides que estan excloses de la sincronització.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Recursió</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Afegir a la llista de sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Establir profunditat de recursió</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Destinació '{target}' senyalitzada per a nova sincronització.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>No s'ha pogut notificar la destinació '{target}' a causa d'un error.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>S'ha omès la senyalització de la destinació '{target}'. Tipus de notificació desconegut: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>S'ha omès la senyalització de la destinació '{target}' a causa de la senyalització desactivada.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>S'ha omès la senyalització de la destinació '{target}' a causa d'un context no vàlid. Contexts permesos: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Taula '{table}' omesa - no hi ha canvis des de l'última sincronització.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sincronització d'Assets iniciada</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sincronització iniciada.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sincronització iniciada - s'hauria de processar en els propers 15 minuts.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Estat de taula actualitzat.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number} fitxers d'URL de hook creats</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>No s'han bolcat dades per a processament posterior. El procés de sincronització seleccionat no ha produït cap dada per sincronitzar al sistema destinació.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>El sistema '{target}' està bloquejat, per tant no es crea cap fitxer d'url.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Les taules següents han canviat, si us plau contacteu amb el vostre administrador de TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>El sistema '{system} està bloquejat per tant no es crea cap fitxer de bolcat per a ell.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Si us plau, seleccioneu una pàgina de l'arbre de pàgines.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>No s'ha pogut carregar el registre per a la pàgina seleccionada: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>El tipus de pàgina no s'ha de sincronitzar.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>El fitxer d'estat de taula no és escrivible.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>No hi ha pàgines marcades per sincronitzar.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Ja hi ha una preparació de sincronització en curs. Si us plau, torneu a intentar-ho d'aquí a uns 5 minuts.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>No s'ha pogut crear el fitxer Zip per a {file}.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>No s'ha pogut moure el fitxer {file} a {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Si us plau, seleccioneu com s'ha de marcar la pàgina.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>La pàgina ja ha estat marcada per a sincronització</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Les taules MM com {tableName} ja no són compatibles.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL té entrades corrompudes. (Entrades amb uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>fet</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Aquesta tasca pot trigar una estona, si us plau sigueu pacients.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Notícies</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Usuaris i grups del Backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Grups del Frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Tasques del Scheduler</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirects</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Estat de taula</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Pàgines individuals amb contingut</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ca.locallang_scheduler.xlf
+++ b/Resources/Private/Language/ca.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ca" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Importació de sincronització</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Tasca per importar sincronitzacions</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Ruta on s'emmagatzemen els fitxers de sincronització.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Ruta on s'emmagatzemen els fitxers d'URL a executar.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/cs.locallang.xlf
+++ b/Resources/Private/Language/cs.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="cs" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Uzamknout synchronizační modul</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Zpráva pro uživatele v případě aktivního zámku</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/cs.locallang_mod.xlf
+++ b/Resources/Private/Language/cs.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="cs" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/cs.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/cs.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="cs" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Modul pro synchronizaci obsahu z produkčního systému do jednoho nebo více cílových systémů.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Vytvořit nový Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Vytvořit Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Vynutit úplný sync. Úplný sync této položky je spuštěn, i když je možný přírůstkový sync. Mělo by se tomu pokud možno vyhnout.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Odstraní zastaralé záznamy v cílovém systému. Všechny záznamy označené jako skryté nebo smazané, nebo kde čas konce záznamu je datum v minulosti, budou v cílovém systému smazány.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Stav sync tabulky</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabulka</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Čas posledního sync</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Typ posledního sync</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Uživatel posledního sync</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>úplný</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>přírůstkový</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Seznam Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Čekající Syncs</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} soubor(ů) čeká na synchronizaci {size}. Nejstarší soubor z {oldestFile}, tedy stár {minutes} minut.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Soubor</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Velikost</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Položka</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Akce</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Cíl Sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Cíl '{target}' zakázán pro sync.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Cíl '{target}' povolen pro sync.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Uzamknout modul sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Odemknout modul sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Uzamknout cíl sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Odemknout cíl sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Pouze vybraná stránka</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Vybraná stránka a všechny {pages} podstránky</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(z toho {deleted} jsou smazané, {noaccess} jsou blokované a {falses} mají špatný typ stránky)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} podstránek s {deleted} smazanými a {noaccess} nepřístupnými)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Stránka: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Existují omezené podoblasti, které jsou vyloučeny ze sync.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekurze</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Přidat do seznamu sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Nastavit hloubku rekurze</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Cíl '{target}' byl signalizován pro nový sync.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Cíl '{target}' nemohl být upozorněn kvůli chybě.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Přeskočeno signalizování cíle '{target}'. Neznámý typ oznámení: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Přeskočeno signalizování cíle '{target}' kvůli zakázanému signalizování.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Přeskočeno signalizování cíle '{target}' kvůli neplatnému kontextu. Povolené kontexty: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabulka '{table}' přeskočena - žádné změny od posledního sync.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sync assets zahájen</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync zahájen.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync spuštěn - měl by být zpracován během příštích 15 minut.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Stav tabulky aktualizován.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Vytvořeno {number} hook URL souborů</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Žádná data nebyla uložena pro další zpracování. Vybraný proces sync nevytvořil žádná data pro synchronizaci do cílového systému.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Systém '{target}' je uzamčen, takže není vytvořen žádný url soubor.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Následující tabulky se změnily, kontaktujte prosím svého TYPO3 administrátora:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Systém '{system} je uzamčen, takže pro něj není vytvořen žádný dump-soubor.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Vyberte prosím stránku ze stromu stránek.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Nelze načíst záznam pro vybranou stránku: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Tento typ stránky nesmí být synchronizován.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Soubor table-state není zapisovatelný.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Nejsou označeny žádné stránky k sync.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Příprava sync již probíhá. Zkuste to prosím znovu za asi 5 minut.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zipový soubor pro {file} nemohl být vytvořen.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Soubor {file} nemohl být přesunut do {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Vyberte prosím, jak má být stránka označena.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Stránka již byla označena k synchronizaci</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM tabulky jako {tableName} již nejsou podporovány.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL má poškozené záznamy. (Záznamy s uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>hotovo</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Tato úloha může trvat nějakou dobu, buďte prosím trpěliví.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Novinky</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend uživatelé a skupiny</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend skupiny</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Scheduler úlohy</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Přesměrování</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Stav tabulky</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Jednotlivé stránky s obsahem</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/cs.locallang_scheduler.xlf
+++ b/Resources/Private/Language/cs.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="cs" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Import synchronizace</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Úloha pro import synchronizací</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Cesta, kde jsou uloženy synchronizační soubory.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Cesta, kde jsou uloženy soubory URL k provedení.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/da.locallang.xlf
+++ b/Resources/Private/Language/da.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="da" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Lås synkroniseringsmodul</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Besked til brugere i tilfælde af aktiv lås</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/da.locallang_mod.xlf
+++ b/Resources/Private/Language/da.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="da" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/da.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/da.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="da" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Et modul til synkronisering af indhold fra et produktionssystem til et enkelt eller flere målsystemer.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Opret ny Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Opret Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Gennemtving fuld sync. En fuld sync af dette element startes, selvom en trinvis sync er mulig. Dette bør undgås hvis muligt.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Sletter forældede poster på målsystemet. Alle poster, der er markeret som skjulte eller slettede, eller hvor postens sluttidspunkt er en dato i fortiden, vil blive slettet på målsystemet.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Tabel sync status</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabel</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Sidste sync tidspunkt</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Sidste sync type</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Sidste sync bruger</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>fuld</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>trinvis</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Sync Liste</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Ventende Syncs</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} fil(er) venter på synkronisering {size}. Ældste fil fra {oldestFile} og derfor {minutes} minutter gammel.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Fil</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Størrelse</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Element</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Handling</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Sync mål:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Mål '{target}' deaktiveret for sync.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Mål '{target}' aktiveret for sync.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Lås sync modul</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Lås sync modul op</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Lås sync mål: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Lås sync mål op: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Kun valgte side</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Valgte side og alle {pages} undersider</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(hvoraf {deleted} er slettet, {noaccess} er blokeret, og {falses} har forkert sidetype)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} undersider med {deleted} slettet og {noaccess} utilgængelige)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Side: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Der er begrænsede underområder, som er udelukket fra sync.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekursion</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Tilføj til sync liste</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Indstil rekursionsdybde</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Signaleret '{target}' mål for ny sync.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Mål '{target}' kunne ikke underrettes på grund af en fejl.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Sprunget signalering af '{target}' mål over. Ukendt notifikationstype: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Sprunget signalering af '{target}' mål over på grund af deaktiveret signalering.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Sprunget signalering af '{target}' mål over på grund af ugyldig kontekst. Tilladte kontekster: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabel '{table}' sprunget over - ingen ændringer siden sidste sync.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sync assets startet</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync startet.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync startet - skulle behandles inden for de næste 15 minutter.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Tabelstatus opdateret.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Oprettet {number} hook URL filer</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Ingen data gemt til videre behandling. Den valgte sync proces producerede ingen data til synkronisering til målsystemet.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>System '{target}' er låst, så ingen url fil oprettes.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Følgende tabeller er ændret, kontakt venligst din TYPO3 administrator:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>System '{system} er låst, så ingen dump-fil oprettes til det.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Vælg venligst en side fra sidetræet.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Kunne ikke indlæse post for valgte side: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Sidetypen må ikke synkroniseres.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Table-state-fil er ikke skrivbar.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Der er ingen sider markeret til sync.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Der er allerede en sync-forberedelse i gang. Prøv venligst igen om ca. 5 minutter.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zipfil til {file} kunne ikke oprettes.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Fil {file} kunne ikke flyttes til {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Vælg venligst hvordan siden skal markeres.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Siden er allerede markeret til synkronisering</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM tabeller som {tableName} understøttes ikke længere.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL har korrupte poster. (Poster med uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>færdig</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Denne opgave kan tage nogen tid, vær venligst tålmodig.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Nyheder</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend brugere og grupper</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend grupper</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Scheduler opgaver</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Omdirigeringer</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Tabelstatus</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Enkelte sider med indhold</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/da.locallang_scheduler.xlf
+++ b/Resources/Private/Language/da.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="da" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Sync-import</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Opgave til import af synkroniseringer</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Sti hvor synkroniseringsfilerne er gemt.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Sti hvor URL-filerne til udførelse er gemt.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/de.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/de.locallang_mod_sync.xlf
@@ -1,240 +1,307 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-    <file target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z"
-          product-name="nr_sync">
-        <header/>
-        <body>
-            <trans-unit id="mlang_tabs_tab">
-                <target>Sync</target>
-            </trans-unit>
-            <trans-unit id="mlang_labels_tablabel">
-                <target>Sync</target>
-            </trans-unit>
-            <trans-unit id="mlang_labels_tabdescr">
-                <target>Ein Modul zur Synchronisierung von Inhalten von einem Produktionssystem auf ein einzelnes oder auf mehrere Ziel-Systeme.</target>
-            </trans-unit>
-
-            <!-- Labels -->
-            <trans-unit id="headline.create_sync">
-                <target>Neue Synchronisierung erstellen</target>
-            </trans-unit>
-            <trans-unit id="button.create_sync">
-                <target>Synchronisierung erstellen</target>
-            </trans-unit>
-            <trans-unit id="label.force_full_sync">
-                <target>Erzwinge eine vollständige Synchronisierung. Eine vollständige Synchronisierung dieses Elements wird initiiert, auch wenn eine inkrementelle Synchronisierung möglich ist. Dies sollte, wenn möglich, vermieden werden.</target>
-            </trans-unit>
-            <trans-unit id="label.delete_obsolete_rows">
-                <target>Löscht veraltete Datensätze auf dem Zielsystem. Alle Datensätze, die als ausgeblendet oder  gelöscht markiert sind oder bei denen die Endzeit des Datensatzes ein Datum in der Vergangenheit ist, werden auf dem Zielsystem gelöscht.</target>
-            </trans-unit>
-            <trans-unit id="headline.table_state">
-                <target>Synchronisierungsstatus der Tabellen</target>
-            </trans-unit>
-            <trans-unit id="column.table">
-                <target>Tabelle</target>
-            </trans-unit>
-            <trans-unit id="column.last_sync">
-                <target>Zuletzt synchronisiert</target>
-            </trans-unit>
-            <trans-unit id="column.last_type">
-                <target>Typ der letzten Synchronisierung</target>
-            </trans-unit>
-            <trans-unit id="column.last_user">
-                <target>Zuletzt angestoßen durch</target>
-            </trans-unit>
-            <trans-unit id="sync_type.full">
-                <target>vollständig</target>
-            </trans-unit>
-            <trans-unit id="sync_type.incr">
-                <target>inkrementell</target>
-            </trans-unit>
-            <trans-unit id="headline.sync_list">
-                <target>Synchronisierungsliste</target>
-            </trans-unit>
-            <trans-unit id="headline.waiting_syncs">
-                <target>Wartende Synchronisierungen</target>
-            </trans-unit>
-            <trans-unit id="waitingfiles">
-                <target>{files} Dateien warten auf Synchronisierung ({size}). Die älteste Datei ist von {oldestFile} und somit {minutes} Minuten alt.</target>
-            </trans-unit>
-            <trans-unit id="column.file">
-                <target>Datei</target>
-            </trans-unit>
-            <trans-unit id="column.size">
-                <target>Größe</target>
-            </trans-unit>
-            <trans-unit id="column.item">
-                <target>Seite</target>
-            </trans-unit>
-            <trans-unit id="column.action">
-                <target>Aktion</target>
-            </trans-unit>
-            <trans-unit id="label.sync_target">
-                <target>Zielsystem:</target>
-            </trans-unit>
-            <trans-unit id="message.target_locked">
-                <target>Ziel '{target}' wurde für die Synchronisierung gesperrt.</target>
-            </trans-unit>
-            <trans-unit id="message.target_unlocked">
-                <target>Ziel '{target}' wurde für die Synchronisierung aktiviert.</target>
-            </trans-unit>
-            <trans-unit id="label.lock_module">
-                <target>Sync-Modul sperren</target>
-            </trans-unit>
-            <trans-unit id="label.unlock_module">
-                <target>Sync-Modul entsperren</target>
-            </trans-unit>
-            <trans-unit id="label.lock_target">
-                <target>Sync-Ziel sperren: {system}</target>
-            </trans-unit>
-            <trans-unit id="label.unlock_target">
-                <target>Sync-Ziel entsperren: {system}</target>
-            </trans-unit>
-            <trans-unit id="label.page_only">
-                <target>Nur die ausgewählte Seite</target>
-            </trans-unit>
-            <trans-unit id="label.page_and_subpages">
-                <target>Ausgewählte Seite und alle {pages} Unterseiten</target>
-            </trans-unit>
-            <trans-unit id="label.subpages_including">
-                <target>(davon sind {deleted} gelöscht, {noaccess} gesperrt und {falses} haben den falschen Seitentyp)</target>
-            </trans-unit>
-            <trans-unit id="label.list_with_subs">
-                <target>({pages} Unterseiten, inklusive {deleted} gelöschte und {noaccess} gesperrt)</target>
-            </trans-unit>
-            <trans-unit id="label.page">
-                <target>Seite: {id}</target>
-            </trans-unit>
-            <trans-unit id="label.excluded_pages">
-                <target>Es gibt eingeschränkte Unterbereiche, die von der Synchronisierung ausgeschlossen sind.</target>
-            </trans-unit>
-            <trans-unit id="label.recursion">
-                <target>Rekursion</target>
-            </trans-unit>
-            <trans-unit id="button.add_to_list">
-                <target>Zur Synchronisierungsliste hinzufügen</target>
-            </trans-unit>
-            <trans-unit id="button.recursion_depth">
-                <target>Rekursionstiefe setzen</target>
-            </trans-unit>
-            <trans-unit id="message.notify_success">
-                <target>Ziel '{target}' wurde über neue Synchronisierungen benachrichtigt.</target>
-            </trans-unit>
-            <trans-unit id="message.notify_failed">
-                <target>Ziel '{target}' konnte aufgrund eines Fehlers nicht benachrichtigt werden.</target>
-            </trans-unit>
-            <trans-unit id="message.notify_unknown">
-                <target>Benachrichtigung für '{target}' wurde übersprungen. Type '{notify_type}' ist nicht bekannt.</target>
-            </trans-unit>
-            <trans-unit id="message.notify_disabled">
-                <target>Benachrichtigung für '{target}' wurde übersprungen, da deaktiviert.</target>
-            </trans-unit>
-            <trans-unit id="message.notify_skipped_context">
-                <target>Benachrichtigung für '{target}' wurde wegen falschem Kontext übersprungen. Erlaubte Kontexte sind: {allowed_contexts}</target>
-            </trans-unit>
-            <trans-unit id="message.notify_skipped_table">
-                <target>Tabelle '{table}' übersprungen – keine Änderungen seit der letzten Synchronisierung.</target>
-            </trans-unit>
-            <trans-unit id="success.sync_assest_init">
-                <target>Synchronisierung der Assets eingeleitet</target>
-            </trans-unit>
-            <trans-unit id="success.sync_initiated">
-                <target>Synchronisierung eingeleitet.</target>
-            </trans-unit>
-            <trans-unit id="success.sync_in_progress">
-                <target>Synchronisierung wurde gestartet und sollte in den nächsten 15 Minuten abgearbeitet werden.</target>
-            </trans-unit>
-            <trans-unit id="message.table_state_success">
-                <target>Tabellenstatus wurde aktualisiert.</target>
-            </trans-unit>
-            <trans-unit id="message.hook_files">
-                <target>{number} Hook-Url-Dateien wurden erstellt</target>
-            </trans-unit>
-            <trans-unit id="info.no_data_dumped">
-                <target>Es wurden keine Daten zur weiteren Verarbeitung erzeugt. Der ausgewählte Synchronisierungsprozess lieferte keine Daten, die mit dem Zielsystem synchronisiert werden sollten.</target>
-            </trans-unit>
-            <trans-unit id="warning.urls_system_locked">
-                <target>System '{target}' ist für die Synchronisierung gesperrt. Es werden keine Hook-Dateien erstellt.</target>
-            </trans-unit>
-            <trans-unit id="warning.table_state">
-                <target>Die folgenden Tabellen weisen Änderungen auf, bitte kontaktieren Sie Ihren TYPO3 Administrator:</target>
-            </trans-unit>
-            <trans-unit id="warning.system_locked">
-                <target>Das System '{system}' ist für die Synchronisierung gesperrt, daher werden keine Dateien zur Synchronisierung erstellt.</target>
-            </trans-unit>
-            <trans-unit id="error.no_page">
-                <target>Bitte wählen Sie eine Seite aus dem Seitenbaum.</target>
-            </trans-unit>
-            <trans-unit id="error.page_not_load">
-                <target>Der Datensatz für die Seite '{page_selected}' konnte nicht geladen werden.</target>
-            </trans-unit>
-            <trans-unit id="error.page_type_not_allowed">
-                <target>Der gewählte Seitentyp darf nicht synchronisiert werden.</target>
-            </trans-unit>
-            <trans-unit id="error.could_not_write_tablestate">
-                <target>Datei für Tabellenstatus kann nicht geschrieben werden.</target>
-            </trans-unit>
-            <trans-unit id="error.no_pages_marked">
-                <target>Es sind keine Seiten für die Synchronisierung vorgemerkt.</target>
-            </trans-unit>
-            <trans-unit id="error.last_sync_not_finished">
-                <target>Die letzte Synchronisierungsvorbereitung ist noch nicht abgeschlossen. Bitte versuchen Sie es in 5 Minuten noch einmal.</target>
-            </trans-unit>
-            <trans-unit id="error.zip_failure">
-                <target>Archiv für {file} kann nicht erzeugt werden.</target>
-            </trans-unit>
-            <trans-unit id="error.cannot_move_file">
-                <target>Die Datei {file} konnte nicht nach {target} kopiert werden.</target>
-            </trans-unit>
-            <trans-unit id="error.select_mark_type">
-                <target>Bitte wählen Sie aus, wie die Seite zur Übertragung vorgemerkt werden soll.</target>
-            </trans-unit>
-            <trans-unit id="error.page_is_marked">
-                <target>Die Seite wurde bereits für die Synchronisierung vorgemerkt.</target>
-            </trans-unit>
-            <trans-unit id="error.mm_tables">
-                <source>MM-Tabellen wie {tableName} werden nicht mehr unterstützt.</source>
-            </trans-unit>
-
-            <!-- FAL -->
-            <trans-unit id="error.fal_dirty">
-                <target>FAL hat korrupte Einträge. (Einträge mit uid_foreign = 0)</target>
-            </trans-unit>
-            <trans-unit id="label.done">
-                <target>Fertig</target>
-            </trans-unit>
-            <trans-unit id="label.clean_fal">
-                <target>Diese Aufgaben können einige Zeit in Anspruch nehmen, bitte haben Sie etwas Geduld.</target>
-            </trans-unit>
-
-            <!-- Sync modules -->
-            <trans-unit id="mod_news">
-                <target>Nachrichten</target>
-            </trans-unit>
-            <trans-unit id="mod_fal">
-                <target>TYPO3: Medien und Bilder</target>
-            </trans-unit>
-            <trans-unit id="mod_asset">
-                <target>Assets</target>
-            </trans-unit>
-            <trans-unit id="mod_be_users">
-                <target>TYPO3: Backend-Benutzer und -Gruppen</target>
-            </trans-unit>
-            <trans-unit id="mod_fe_groups">
-                <target>TYPO3: Frontend-Gruppen</target>
-            </trans-unit>
-            <trans-unit id="mod_scheduler">
-                <target>TYPO3: Aufgaben des Planers</target>
-            </trans-unit>
-            <trans-unit id="mod_redirect">
-                <target>TYPO3: Weiterleitungen</target>
-            </trans-unit>
-            <trans-unit id="mod_tableState">
-                <target>Tabellenstatus</target>
-            </trans-unit>
-            <trans-unit id="mod_singlePage">
-                <target>TYPO3: Einzelne Seiten mit Inhalt</target>
-            </trans-unit>
-        </body>
-    </file>
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+    <body>
+      <trans-unit id="mlang_tabs_tab">
+        <source>Sync</source>
+        <target>Sync</target>
+      </trans-unit>
+      <trans-unit id="mlang_labels_tablabel">
+        <source>Sync</source>
+        <target>Sync</target>
+      </trans-unit>
+      <trans-unit id="mlang_labels_tabdescr">
+        <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Ein Modul zur Synchronisierung von Inhalten von einem Produktionssystem auf ein einzelnes oder auf mehrere Ziel-Systeme.</target>
+      </trans-unit>
+      <trans-unit id="headline.create_sync">
+        <source>Create new Sync</source>
+        <target>Neue Synchronisierung erstellen</target>
+      </trans-unit>
+      <trans-unit id="button.create_sync">
+        <source>Create Sync</source>
+        <target>Synchronisierung erstellen</target>
+      </trans-unit>
+      <trans-unit id="label.force_full_sync">
+        <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Erzwinge eine vollständige Synchronisierung. Eine vollständige Synchronisierung dieses Elements wird initiiert, auch wenn eine inkrementelle Synchronisierung möglich ist. Dies sollte, wenn möglich, vermieden werden.</target>
+      </trans-unit>
+      <trans-unit id="label.delete_obsolete_rows">
+        <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Löscht veraltete Datensätze auf dem Zielsystem. Alle Datensätze, die als ausgeblendet oder gelöscht markiert sind oder bei denen die Endzeit des Datensatzes ein Datum in der Vergangenheit ist, werden auf dem Zielsystem gelöscht.</target>
+      </trans-unit>
+      <trans-unit id="headline.table_state">
+        <source>Table sync status</source>
+        <target>Synchronisierungsstatus der Tabellen</target>
+      </trans-unit>
+      <trans-unit id="column.table">
+        <source>Table</source>
+        <target>Tabelle</target>
+      </trans-unit>
+      <trans-unit id="column.last_sync">
+        <source>Last sync time</source>
+        <target>Zuletzt synchronisiert</target>
+      </trans-unit>
+      <trans-unit id="column.last_type">
+        <source>Last sync type</source>
+        <target>Typ der letzten Synchronisierung</target>
+      </trans-unit>
+      <trans-unit id="column.last_user">
+        <source>Last sync user</source>
+        <target>Zuletzt angestoßen durch</target>
+      </trans-unit>
+      <trans-unit id="sync_type.full">
+        <source>full</source>
+        <target>vollständig</target>
+      </trans-unit>
+      <trans-unit id="sync_type.incr">
+        <source>incremental</source>
+        <target>inkrementell</target>
+      </trans-unit>
+      <trans-unit id="headline.sync_list">
+        <source>Sync List</source>
+        <target>Synchronisierungsliste</target>
+      </trans-unit>
+      <trans-unit id="headline.waiting_syncs">
+        <source>Waiting Syncs</source>
+        <target>Wartende Synchronisierungen</target>
+      </trans-unit>
+      <trans-unit id="waitingfiles">
+        <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} Dateien warten auf Synchronisierung ({size}). Die älteste Datei ist von {oldestFile} und somit {minutes} Minuten alt.</target>
+      </trans-unit>
+      <trans-unit id="column.file">
+        <source>File</source>
+        <target>Datei</target>
+      </trans-unit>
+      <trans-unit id="column.size">
+        <source>Size</source>
+        <target>Größe</target>
+      </trans-unit>
+      <trans-unit id="column.item">
+        <source>Item</source>
+        <target>Seite</target>
+      </trans-unit>
+      <trans-unit id="column.action">
+        <source>Action</source>
+        <target>Aktion</target>
+      </trans-unit>
+      <trans-unit id="label.sync_target">
+        <source>Sync target:</source>
+        <target>Zielsystem:</target>
+      </trans-unit>
+      <trans-unit id="message.target_locked">
+        <source>Target '{target}' disabled for sync.</source>
+        <target>Ziel '{target}' wurde für die Synchronisierung gesperrt.</target>
+      </trans-unit>
+      <trans-unit id="message.target_unlocked">
+        <source>Target '{target}' enabled for sync.</source>
+        <target>Ziel '{target}' wurde für die Synchronisierung aktiviert.</target>
+      </trans-unit>
+      <trans-unit id="label.lock_module">
+        <source>Lock sync module</source>
+        <target>Sync-Modul sperren</target>
+      </trans-unit>
+      <trans-unit id="label.unlock_module">
+        <source>Unlock sync module</source>
+        <target>Sync-Modul entsperren</target>
+      </trans-unit>
+      <trans-unit id="label.lock_target">
+        <source>Lock sync target: {system}</source>
+        <target>Sync-Ziel sperren: {system}</target>
+      </trans-unit>
+      <trans-unit id="label.unlock_target">
+        <source>Unlock sync target: {system}</source>
+        <target>Sync-Ziel entsperren: {system}</target>
+      </trans-unit>
+      <trans-unit id="label.page_only">
+        <source>Only selected page</source>
+        <target>Nur die ausgewählte Seite</target>
+      </trans-unit>
+      <trans-unit id="label.page_and_subpages">
+        <source>Selected page and all {pages} sub pages</source>
+        <target>Ausgewählte Seite und alle {pages} Unterseiten</target>
+      </trans-unit>
+      <trans-unit id="label.subpages_including">
+        <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(davon sind {deleted} gelöscht, {noaccess} gesperrt und {falses} haben den falschen Seitentyp)</target>
+      </trans-unit>
+      <trans-unit id="label.list_with_subs">
+        <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} Unterseiten, inklusive {deleted} gelöschte und {noaccess} gesperrt)</target>
+      </trans-unit>
+      <trans-unit id="label.page">
+        <source>Page: {id}</source>
+        <target>Seite: {id}</target>
+      </trans-unit>
+      <trans-unit id="label.excluded_pages">
+        <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Es gibt eingeschränkte Unterbereiche, die von der Synchronisierung ausgeschlossen sind.</target>
+      </trans-unit>
+      <trans-unit id="label.recursion">
+        <source>Recursion</source>
+        <target>Rekursion</target>
+      </trans-unit>
+      <trans-unit id="button.add_to_list">
+        <source>Add to sync list</source>
+        <target>Zur Synchronisierungsliste hinzufügen</target>
+      </trans-unit>
+      <trans-unit id="button.recursion_depth">
+        <source>Set recursion depth</source>
+        <target>Rekursionstiefe setzen</target>
+      </trans-unit>
+      <trans-unit id="message.notify_success">
+        <source>Signaled '{target}' target for new sync.</source>
+        <target>Ziel '{target}' wurde über neue Synchronisierungen benachrichtigt.</target>
+      </trans-unit>
+      <trans-unit id="message.notify_failed">
+        <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Ziel '{target}' konnte aufgrund eines Fehlers nicht benachrichtigt werden.</target>
+      </trans-unit>
+      <trans-unit id="message.notify_unknown">
+        <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Benachrichtigung für '{target}' wurde übersprungen. Type '{notify_type}' ist nicht bekannt.</target>
+      </trans-unit>
+      <trans-unit id="message.notify_disabled">
+        <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Benachrichtigung für '{target}' wurde übersprungen, da deaktiviert.</target>
+      </trans-unit>
+      <trans-unit id="message.notify_skipped_context">
+        <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Benachrichtigung für '{target}' wurde wegen falschem Kontext übersprungen. Erlaubte Kontexte sind: {allowed_contexts}</target>
+      </trans-unit>
+      <trans-unit id="message.notify_skipped_table">
+        <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabelle '{table}' übersprungen – keine Änderungen seit der letzten Synchronisierung.</target>
+      </trans-unit>
+      <trans-unit id="success.sync_assest_init">
+        <source>Sync assets initiated</source>
+        <target>Synchronisierung der Assets eingeleitet</target>
+      </trans-unit>
+      <trans-unit id="success.sync_initiated">
+        <source>Sync initiated.</source>
+        <target>Synchronisierung eingeleitet.</target>
+      </trans-unit>
+      <trans-unit id="success.sync_in_progress">
+        <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Synchronisierung wurde gestartet und sollte in den nächsten 15 Minuten abgearbeitet werden.</target>
+      </trans-unit>
+      <trans-unit id="message.table_state_success">
+        <source>Updated table state.</source>
+        <target>Tabellenstatus wurde aktualisiert.</target>
+      </trans-unit>
+      <trans-unit id="message.hook_files">
+        <source>Created {number} hook URL files</source>
+        <target>{number} Hook-Url-Dateien wurden erstellt</target>
+      </trans-unit>
+      <trans-unit id="info.no_data_dumped">
+        <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Es wurden keine Daten zur weiteren Verarbeitung erzeugt. Der ausgewählte Synchronisierungsprozess lieferte keine Daten, die mit dem Zielsystem synchronisiert werden sollten.</target>
+      </trans-unit>
+      <trans-unit id="warning.urls_system_locked">
+        <source>System '{target}' is locked, so no url file is created.</source>
+        <target>System '{target}' ist für die Synchronisierung gesperrt. Es werden keine Hook-Dateien erstellt.</target>
+      </trans-unit>
+      <trans-unit id="warning.table_state">
+        <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Die folgenden Tabellen weisen Änderungen auf, bitte kontaktieren Sie Ihren TYPO3 Administrator:</target>
+      </trans-unit>
+      <trans-unit id="warning.system_locked">
+        <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Das System '{system}' ist für die Synchronisierung gesperrt, daher werden keine Dateien zur Synchronisierung erstellt.</target>
+      </trans-unit>
+      <trans-unit id="error.no_page">
+        <source>Please select a page from the page tree.</source>
+        <target>Bitte wählen Sie eine Seite aus dem Seitenbaum.</target>
+      </trans-unit>
+      <trans-unit id="error.page_not_load">
+        <source>Could not load record for selected page: {page_selected}</source>
+        <target>Der Datensatz für die Seite '{page_selected}' konnte nicht geladen werden.</target>
+      </trans-unit>
+      <trans-unit id="error.page_type_not_allowed">
+        <source>The page type must not be synchronized.</source>
+        <target>Der gewählte Seitentyp darf nicht synchronisiert werden.</target>
+      </trans-unit>
+      <trans-unit id="error.could_not_write_tablestate">
+        <source>Table-state-file is not writable.</source>
+        <target>Datei für Tabellenstatus kann nicht geschrieben werden.</target>
+      </trans-unit>
+      <trans-unit id="error.no_pages_marked">
+        <source>There are no pages marked to sync.</source>
+        <target>Es sind keine Seiten für die Synchronisierung vorgemerkt.</target>
+      </trans-unit>
+      <trans-unit id="error.last_sync_not_finished">
+        <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Die letzte Synchronisierungsvorbereitung ist noch nicht abgeschlossen. Bitte versuchen Sie es in 5 Minuten noch einmal.</target>
+      </trans-unit>
+      <trans-unit id="error.zip_failure">
+        <source>Zipfile for {file} could not be created.</source>
+        <target>Archiv für {file} kann nicht erzeugt werden.</target>
+      </trans-unit>
+      <trans-unit id="error.cannot_move_file">
+        <source>File {file} could not be moved to {target}.</source>
+        <target>Die Datei {file} konnte nicht nach {target} kopiert werden.</target>
+      </trans-unit>
+      <trans-unit id="error.select_mark_type">
+        <source>Please select how the page should be marked.</source>
+        <target>Bitte wählen Sie aus, wie die Seite zur Übertragung vorgemerkt werden soll.</target>
+      </trans-unit>
+      <trans-unit id="error.page_is_marked">
+        <source>The page has been already marked for synchronisation</source>
+        <target>Die Seite wurde bereits für die Synchronisierung vorgemerkt.</target>
+      </trans-unit>
+      <trans-unit id="error.mm_tables">
+        <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM-Tabellen wie {tableName} werden nicht mehr unterstützt.</target>
+      </trans-unit>
+      <trans-unit id="error.fal_dirty">
+        <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL hat korrupte Einträge. (Einträge mit uid_foreign = 0)</target>
+      </trans-unit>
+      <trans-unit id="label.done">
+        <source>done</source>
+        <target>Fertig</target>
+      </trans-unit>
+      <trans-unit id="label.clean_fal">
+        <source>This tasks can take some time, please be patient.</source>
+        <target>Diese Aufgaben können einige Zeit in Anspruch nehmen, bitte haben Sie etwas Geduld.</target>
+      </trans-unit>
+      <trans-unit id="mod_news">
+        <source>News</source>
+        <target>Nachrichten</target>
+      </trans-unit>
+      <trans-unit id="mod_fal">
+        <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: Medien und Bilder</target>
+      </trans-unit>
+      <trans-unit id="mod_asset">
+        <source>Assets</source>
+        <target>Assets</target>
+      </trans-unit>
+      <trans-unit id="mod_be_users">
+        <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend-Benutzer und -Gruppen</target>
+      </trans-unit>
+      <trans-unit id="mod_fe_groups">
+        <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend-Gruppen</target>
+      </trans-unit>
+      <trans-unit id="mod_scheduler">
+        <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Aufgaben des Planers</target>
+      </trans-unit>
+      <trans-unit id="mod_redirect">
+        <source>TYPO3: Redirects</source>
+        <target>TYPO3: Weiterleitungen</target>
+      </trans-unit>
+      <trans-unit id="mod_tableState">
+        <source>Table state</source>
+        <target>Tabellenstatus</target>
+      </trans-unit>
+      <trans-unit id="mod_singlePage">
+        <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Einzelne Seiten mit Inhalt</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Language/de.locallang_scheduler.xlf
+++ b/Resources/Private/Language/de.locallang_scheduler.xlf
@@ -1,21 +1,23 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-    <file target-language="de" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z"
-          product-name="nr_sync">
-        <header/>
-        <body>
-            <trans-unit id="tx_nrcsync_scheduler_import.name">
-                <target>Import Sync</target>
-            </trans-unit>
-            <trans-unit id="tx_nrcsync_scheduler_import.description">
-                <target>Task zum Importieren der Sync-Daten</target>
-            </trans-unit>
-            <trans-unit id="syncStoragePath">
-                <target>Pfad, in dem die Synchronisierungsdateien gespeichert sind.</target>
-            </trans-unit>
-            <trans-unit id="syncUrlsPath">
-                <target>Pfad, in dem die auszuführenden URL-Dateien gespeichert sind.</target>
-            </trans-unit>
-        </body>
-    </file>
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+    <body>
+      <trans-unit id="tx_nrcsync_scheduler_import.name">
+        <source>Import Sync</source>
+        <target>Sync-Import</target>
+      </trans-unit>
+      <trans-unit id="tx_nrcsync_scheduler_import.description">
+        <source>Task to import syncs</source>
+        <target>Task zum Importieren der Sync-Daten</target>
+      </trans-unit>
+      <trans-unit id="syncStoragePath">
+        <source>Path where the sync files are stored in.</source>
+        <target>Pfad, in dem die Synchronisierungsdateien gespeichert sind.</target>
+      </trans-unit>
+      <trans-unit id="syncUrlsPath">
+        <source>Path where the urls files to execute are stored in.</source>
+        <target>Pfad, in dem die auszuführenden URL-Dateien gespeichert sind.</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Language/el.locallang.xlf
+++ b/Resources/Private/Language/el.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="el" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Κλείδωμα μονάδας συγχρονισμού</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Μήνυμα για τους χρήστες σε περίπτωση ενεργού κλειδώματος</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/el.locallang_mod.xlf
+++ b/Resources/Private/Language/el.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="el" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/el.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/el.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="el" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Ένα module για συγχρονισμό περιεχομένου από ένα σύστημα παραγωγής σε ένα ή περισσότερα συστήματα προορισμού.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Δημιουργία νέου Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Δημιουργία Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Εξαναγκασμός πλήρους sync. Ένας πλήρης sync αυτού του στοιχείου ξεκινά ακόμα κι αν είναι δυνατός ένας σταδιακός sync. Αυτό θα πρέπει να αποφεύγεται εάν είναι δυνατόν.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Διαγράφει παρωχημένες εγγραφές στο σύστημα προορισμού. Όλες οι εγγραφές που είναι σημειωμένες ως κρυφές ή διαγραμμένες, ή όπου ο χρόνος λήξης της εγγραφής είναι μια ημερομηνία στο παρελθόν, θα διαγραφούν στο σύστημα προορισμού.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Κατάσταση sync πίνακα</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Πίνακας</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Χρόνος τελευταίου sync</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Τύπος τελευταίου sync</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Χρήστης τελευταίου sync</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>πλήρης</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>σταδιακός</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Λίστα Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Syncs σε αναμονή</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} αρχείο/α σε αναμονή για συγχρονισμό {size}. Το παλαιότερο αρχείο από {oldestFile} και επομένως {minutes} λεπτών.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Αρχείο</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Μέγεθος</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Στοιχείο</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Ενέργεια</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Προορισμός Sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Ο προορισμός '{target}' απενεργοποιήθηκε για sync.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Ο προορισμός '{target}' ενεργοποιήθηκε για sync.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Κλείδωμα module sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Ξεκλείδωμα module sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Κλείδωμα προορισμού sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Ξεκλείδωμα προορισμού sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Μόνο η επιλεγμένη σελίδα</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Επιλεγμένη σελίδα και όλες οι {pages} υποσελίδες</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(από τις οποίες {deleted} είναι διαγραμμένες, {noaccess} είναι αποκλεισμένες και {falses} έχουν λάθος τύπο σελίδας)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} υποσελίδες με {deleted} διαγραμμένες και {noaccess} απρόσιτες)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Σελίδα: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Υπάρχουν περιορισμένες υποπεριοχές που εξαιρούνται από το sync.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Αναδρομή</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Προσθήκη στη λίστα sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Ορισμός βάθους αναδρομής</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Σηματοδοτήθηκε ο προορισμός '{target}' για νέο sync.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Ο προορισμός '{target}' δεν μπόρεσε να ειδοποιηθεί λόγω σφάλματος.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Παραλείφθηκε η σηματοδότηση του προορισμού '{target}'. Άγνωστος τύπος ειδοποίησης: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Παραλείφθηκε η σηματοδότηση του προορισμού '{target}' λόγω απενεργοποιημένης σηματοδότησης.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Παραλείφθηκε η σηματοδότηση του προορισμού '{target}' λόγω μη έγκυρου πλαισίου. Επιτρεπόμενα πλαίσια: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Ο πίνακας '{table}' παραλείφθηκε - καμία αλλαγή από το τελευταίο sync.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Το Sync assets ξεκίνησε</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Το Sync ξεκίνησε.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Το Sync ξεκίνησε - θα πρέπει να επεξεργαστεί εντός των επόμενων 15 λεπτών.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Η κατάσταση του πίνακα ενημερώθηκε.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Δημιουργήθηκαν {number} αρχεία hook URL</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Δεν αποθηκεύτηκαν δεδομένα για περαιτέρω επεξεργασία. Η επιλεγμένη διαδικασία sync δεν παρήγαγε δεδομένα για συγχρονισμό στο σύστημα προορισμού.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Το σύστημα '{target}' είναι κλειδωμένο, επομένως δεν δημιουργείται αρχείο url.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Οι ακόλουθοι πίνακες έχουν αλλάξει, παρακαλώ επικοινωνήστε με τον διαχειριστή TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Το σύστημα '{system} είναι κλειδωμένο, επομένως δεν δημιουργείται αρχείο dump γι' αυτό.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Παρακαλώ επιλέξτε μια σελίδα από το δέντρο σελίδων.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Δεν ήταν δυνατή η φόρτωση της εγγραφής για την επιλεγμένη σελίδα: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Ο τύπος σελίδας δεν πρέπει να συγχρονιστεί.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Το αρχείο table-state δεν είναι εγγράψιμο.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Δεν υπάρχουν σελίδες σημειωμένες για sync.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Υπάρχει ήδη προετοιμασία sync σε εξέλιξη. Παρακαλώ δοκιμάστε ξανά σε περίπου 5 λεπτά.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Το αρχείο zip για {file} δεν μπόρεσε να δημιουργηθεί.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Το αρχείο {file} δεν μπόρεσε να μετακινηθεί στο {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Παρακαλώ επιλέξτε πώς θα πρέπει να σημειωθεί η σελίδα.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Η σελίδα έχει ήδη σημειωθεί για συγχρονισμό</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Οι πίνακες MM όπως ο {tableName} δεν υποστηρίζονται πλέον.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>Το FAL έχει κατεστραμμένες εγγραφές. (Εγγραφές με uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>έτοιμο</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Αυτή η εργασία μπορεί να διαρκέσει λίγο, παρακαλώ να είστε υπομονετικοί.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Νέα</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Χρήστες και ομάδες Backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Ομάδες Frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Εργασίες Scheduler</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Ανακατευθύνσεις</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Κατάσταση πίνακα</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Μεμονωμένες σελίδες με περιεχόμενο</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/el.locallang_scheduler.xlf
+++ b/Resources/Private/Language/el.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="el" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Εισαγωγή συγχρονισμού</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Εργασία για εισαγωγή συγχρονισμών</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Διαδρομή όπου αποθηκεύονται τα αρχεία συγχρονισμού.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Διαδρομή όπου αποθηκεύονται τα αρχεία URL προς εκτέλεση.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/es.locallang.xlf
+++ b/Resources/Private/Language/es.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="es" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Bloquear módulo de sincronización</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Mensaje para usuarios en caso de bloqueo activo</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/es.locallang_mod.xlf
+++ b/Resources/Private/Language/es.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="es" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/es.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/es.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="es" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Un módulo para sincronizar contenido desde un sistema de producción a uno o varios sistemas de destino.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Crear nuevo Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Crear Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Forzar una sincronización completa. Se inicia una sincronización completa de este elemento incluso si es posible una sincronización incremental. Esto debería evitarse si es posible.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Elimina registros obsoletos en el sistema de destino. Cualquier registro que esté marcado como oculto o eliminado, o donde la fecha de finalización del registro sea una fecha en el pasado, se eliminará en el sistema de destino.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Estado de sincronización de tabla</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabla</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Última sincronización</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Último tipo de sincronización</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Último usuario de sincronización</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>completa</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>incremental</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Lista de Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Syncs en espera</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} archivo(s) esperando sincronización {size}. Archivo más antiguo de {oldestFile} y por lo tanto tiene {minutes} minutos de antigüedad.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Archivo</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Tamaño</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Elemento</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Acción</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Objetivo de Sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Objetivo '{target}' deshabilitado para sincronización.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Objetivo '{target}' habilitado para sincronización.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Bloquear módulo de sincronización</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Desbloquear módulo de sincronización</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Bloquear objetivo de sincronización: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Desbloquear objetivo de sincronización: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Solo página seleccionada</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Página seleccionada y todas las {pages} subpáginas</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(de las cuales {deleted} están eliminadas, {noaccess} están bloqueadas y {falses} tienen el tipo de página incorrecto)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} subpáginas con {deleted} eliminadas y {noaccess} inaccesibles)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Página: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Hay subáreas restringidas que están excluidas de la sincronización.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Recursión</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Agregar a la lista de sincronización</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Establecer profundidad de recursión</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Señalizado objetivo '{target}' para nueva sincronización.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>No se pudo notificar al objetivo '{target}' debido a un error.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Se omitió la señalización del objetivo '{target}'. Tipo de notificación desconocido: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Se omitió la señalización del objetivo '{target}' debido a que la señalización está deshabilitada.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Se omitió la señalización del objetivo '{target}' debido a un contexto no válido. Contextos permitidos: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabla '{table}' omitida - sin cambios desde la última sincronización.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sincronización de Assets iniciada</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sincronización iniciada.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sincronización iniciada - debería procesarse dentro de los próximos 15 minutos.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Estado de tabla actualizado.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Se crearon {number} archivos de URL de hook</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>No se volcaron datos para un procesamiento adicional. El proceso de sincronización seleccionado no produjo ningún dato para sincronizar con el sistema de destino.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>El sistema '{target}' está bloqueado, por lo que no se crea ningún archivo de URL.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Las siguientes tablas han cambiado, por favor contacte a su administrador de TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>El sistema '{system} está bloqueado, por lo que no se crea ningún archivo de volcado para él.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Por favor seleccione una página del árbol de páginas.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>No se pudo cargar el registro de la página seleccionada: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>El tipo de página no debe sincronizarse.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>El archivo de estado de tabla no es escribible.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>No hay páginas marcadas para sincronizar.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Ya hay una preparación de sincronización en curso. Por favor, inténtelo de nuevo en unos 5 minutos.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>No se pudo crear el archivo zip para {file}.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>El archivo {file} no se pudo mover a {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Por favor seleccione cómo debe marcarse la página.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>La página ya ha sido marcada para sincronización</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Las tablas MM como {tableName} ya no son compatibles.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL tiene entradas corruptas. (Entradas con uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>hecho</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Esta tarea puede llevar algún tiempo, por favor sea paciente.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Noticias</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Usuarios y grupos del backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Grupos del frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Tareas del programador</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirecciones</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Estado de tabla</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Páginas individuales con contenido</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/es.locallang_scheduler.xlf
+++ b/Resources/Private/Language/es.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="es" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Importación de sincronización</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Tarea para importar sincronizaciones</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Ruta donde se almacenan los archivos de sincronización.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Ruta donde se almacenan los archivos de URL a ejecutar.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/fi.locallang.xlf
+++ b/Resources/Private/Language/fi.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="fi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Lukitse synkronointimoduuli</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Viesti käyttäjille aktiivisen lukituksen yhteydessä</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/fi.locallang_mod.xlf
+++ b/Resources/Private/Language/fi.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="fi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/fi.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/fi.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="fi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Moduuli sisällön synkronointiin tuotantojärjestelmästä yhteen tai useampaan kohdejärjestelmään.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Luo uusi Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Luo Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Pakota täysi synkronointi. Tämän kohteen täysi synkronointi käynnistetään, vaikka inkrementaalinen synkronointi olisi mahdollinen. Tätä tulisi välttää, jos mahdollista.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Poistaa vanhentuneet tietueet kohdejärjestelmästä. Kaikki tietueet, jotka on merkitty piilotetuksi tai poistetuksi, tai joiden päättymisaika on menneisyydessä, poistetaan kohdejärjestelmästä.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Taulun synkronointitila</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Taulu</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Viimeisin synkronointi</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Viimeinen synkronointityyppi</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Viimeinen synkronointikäyttäjä</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>täysi</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>inkrementaalinen</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Sync-lista</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Odottavat Sync-toiminnot</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} tiedosto(a) odottaa synkronointia {size}. Vanhin tiedosto {oldestFile} ja näin ollen {minutes} minuuttia vanha.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Tiedosto</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Koko</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Kohde</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Toiminto</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Sync-kohde:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Kohde '{target}' poistettu käytöstä synkronointia varten.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Kohde '{target}' otettu käyttöön synkronointia varten.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Lukitse synkronointimoduuli</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Avaa synkronointimoduuli</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Lukitse synkronointikohde: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Avaa synkronointikohde: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Vain valittu sivu</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Valittu sivu ja kaikki {pages} alasivua</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(joista {deleted} on poistettu, {noaccess} on estetty ja {falses} on väärä sivutyyppi)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} alasivua, joista {deleted} poistettu ja {noaccess} ei saatavilla)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Sivu: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>On rajoitettuja ala-alueita, jotka on suljettu synkronoinnin ulkopuolelle.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekursio</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Lisää synkronointilistalle</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Aseta rekursion syvyys</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Kohde '{target}' ilmoitettu uutta synkronointia varten.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Kohdetta '{target}' ei voitu ilmoittaa virheen vuoksi.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Kohteen '{target}' ilmoittaminen ohitettiin. Tuntematon ilmoitustyyppi: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Kohteen '{target}' ilmoittaminen ohitettiin, koska ilmoittaminen on poistettu käytöstä.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Kohteen '{target}' ilmoittaminen ohitettiin virheellisen kontekstin vuoksi. Sallitut kontekstit: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Taulu '{table}' ohitettiin - ei muutoksia viimeisen synkronoinnin jälkeen.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Assets-synkronointi käynnistetty</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Synkronointi käynnistetty.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Synkronointi aloitettu - pitäisi käsitellä seuraavan 15 minuutin aikana.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Taulun tila päivitetty.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Luotiin {number} hook URL -tiedostoa</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Dataa ei purettu jatkokäsittelyä varten. Valittu synkronointiprosessi ei tuottanut dataa synkronoitavaksi kohdejärjestelmään.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Järjestelmä '{target}' on lukittu, joten URL-tiedostoa ei luoda.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Seuraavat taulut ovat muuttuneet, ota yhteyttä TYPO3-ylläpitäjääsi:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Järjestelmä '{system} on lukittu, joten sille ei luoda dump-tiedostoa.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Valitse sivu sivupuusta.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Valitun sivun tietuetta ei voitu ladata: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Sivutyyppiä ei saa synkronoida.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Taulun tilatiedosto ei ole kirjoitettavissa.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Ei ole sivuja merkittynä synkronointia varten.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Synkronoinnin valmistelu on jo käynnissä. Yritä uudelleen noin 5 minuutin kuluttua.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zip-tiedostoa tiedostolle {file} ei voitu luoda.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Tiedostoa {file} ei voitu siirtää kohteeseen {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Valitse, miten sivu tulisi merkitä.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Sivu on jo merkitty synkronointia varten</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM-taulut, kuten {tableName}, eivät ole enää tuettuja.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL:ssa on korruptoituneita merkintöjä. (Merkinnät, joissa uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>valmis</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Tämä tehtävä voi kestää jonkin aikaa, ole kärsivällinen.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Uutiset</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend-käyttäjät ja -ryhmät</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend-ryhmät</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Ajastetut tehtävät</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Uudelleenohjaukset</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Taulun tila</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Yksittäiset sivut sisällön kanssa</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/fi.locallang_scheduler.xlf
+++ b/Resources/Private/Language/fi.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="fi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Synkronoinnin tuonti</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Tehtävä synkronointien tuomiseen</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Polku, jossa synkronointitiedostot on tallennettu.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Polku, jossa suoritettavat URL-tiedostot on tallennettu.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/fr.locallang.xlf
+++ b/Resources/Private/Language/fr.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Verrouiller le module de synchronisation</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Message pour les utilisateurs en cas de verrouillage actif</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/fr.locallang_mod.xlf
+++ b/Resources/Private/Language/fr.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/fr.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/fr.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Un module pour synchroniser le contenu d'un système de production vers un ou plusieurs systèmes cibles.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Créer un nouveau Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Créer Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Forcer une synchronisation complète. Une synchronisation complète de cet élément est lancée même si une synchronisation incrémentale est possible. Cela devrait être évité si possible.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Supprime les enregistrements obsolètes sur le système cible. Tous les enregistrements marqués comme masqués ou supprimés, ou dont la date de fin est dans le passé, seront supprimés sur le système cible.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>État de synchronisation de la table</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Table</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Dernière synchronisation</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Dernier type de synchronisation</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Dernier utilisateur de synchronisation</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>complète</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>incrémentale</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Liste de Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Syncs en attente</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} fichier(s) en attente de synchronisation {size}. Fichier le plus ancien de {oldestFile} et donc vieux de {minutes} minutes.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Fichier</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Taille</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Élément</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Action</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Cible de Sync :</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Cible '{target}' désactivée pour la synchronisation.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Cible '{target}' activée pour la synchronisation.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Verrouiller le module de synchronisation</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Déverrouiller le module de synchronisation</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Verrouiller la cible de synchronisation : {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Déverrouiller la cible de synchronisation : {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Seulement la page sélectionnée</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Page sélectionnée et toutes les {pages} sous-pages</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(dont {deleted} sont supprimées, {noaccess} sont bloquées et {falses} ont le mauvais type de page)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} sous-pages avec {deleted} supprimées et {noaccess} inaccessibles)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Page : {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Il existe des sous-zones restreintes qui sont exclues de la synchronisation.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Récursion</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Ajouter à la liste de synchronisation</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Définir la profondeur de récursion</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Cible '{target}' signalée pour une nouvelle synchronisation.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>La cible '{target}' n'a pas pu être notifiée en raison d'une erreur.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Signal de la cible '{target}' ignoré. Type de notification inconnu : '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Signal de la cible '{target}' ignoré car la signalisation est désactivée.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Signal de la cible '{target}' ignoré en raison d'un contexte non valide. Contextes autorisés : {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Table '{table}' ignorée - aucun changement depuis la dernière synchronisation.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Synchronisation des Assets initiée</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Synchronisation initiée.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Synchronisation démarrée - devrait être traitée dans les 15 prochaines minutes.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>État de la table mis à jour.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number} fichiers d'URL de hook créés</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Aucune donnée exportée pour un traitement ultérieur. Le processus de synchronisation sélectionné n'a produit aucune donnée à synchroniser vers le système cible.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Le système '{target}' est verrouillé, aucun fichier d'URL n'est donc créé.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Les tables suivantes ont changé, veuillez contacter votre administrateur TYPO3 :</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Le système '{system} est verrouillé, aucun fichier de dump n'est donc créé pour lui.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Veuillez sélectionner une page dans l'arborescence des pages.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Impossible de charger l'enregistrement de la page sélectionnée : {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Le type de page ne doit pas être synchronisé.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Le fichier d'état de table n'est pas accessible en écriture.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Aucune page n'est marquée pour la synchronisation.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Une préparation de synchronisation est déjà en cours. Veuillez réessayer dans environ 5 minutes.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Le fichier zip pour {file} n'a pas pu être créé.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Le fichier {file} n'a pas pu être déplacé vers {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Veuillez sélectionner comment la page doit être marquée.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>La page a déjà été marquée pour la synchronisation</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Les tables MM comme {tableName} ne sont plus prises en charge.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL contient des entrées corrompues. (Entrées avec uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>terminé</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Cette tâche peut prendre un certain temps, veuillez patienter.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Actualités</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3 : FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3 : Utilisateurs et groupes du backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3 : Groupes du frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3 : Tâches planifiées</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3 : Redirections</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>État de la table</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3 : Pages individuelles avec contenu</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/fr.locallang_scheduler.xlf
+++ b/Resources/Private/Language/fr.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="fr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Importation de synchronisation</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Tâche pour importer les synchronisations</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Chemin où les fichiers de synchronisation sont stockés.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Chemin où les fichiers d'URL à exécuter sont stockés.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/he.locallang.xlf
+++ b/Resources/Private/Language/he.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="he" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>נעל מודול סנכרון</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>הודעה למשתמשים במקרה של נעילה פעילה</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/he.locallang_mod.xlf
+++ b/Resources/Private/Language/he.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="he" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/he.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/he.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="he" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>מודול לסנכרון תוכן ממערכת ייצור למערכת יעד בודדת או למספר מערכות יעד.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>צור Sync חדש</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>צור Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>כפה סנכרון מלא. סנכרון מלא של פריט זה יופעל גם אם סנכרון מצטבר אפשרי. יש להימנע מכך במידת האפשר.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>מוחק רשומות מיושנות במערכת היעד. כל הרשומות המסומנות כמוסתרות או נמחקות, או שזמן הסיום שלהן הוא תאריך בעבר, יימחקו במערכת היעד.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>מצב סנכרון טבלה</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>טבלה</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>זמן סנכרון אחרון</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>סוג סנכרון אחרון</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>משתמש סנכרון אחרון</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>מלא</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>מצטבר</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>רשימת Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Syncs ממתינים</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} קובץ/קבצים ממתינים לסנכרון {size}. הקובץ הישן ביותר מ-{oldestFile} ולכן בן {minutes} דקות.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>קובץ</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>גודל</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>פריט</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>פעולה</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>יעד Sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>יעד '{target}' הושבת עבור sync.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>יעד '{target}' הופעל עבור sync.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>נעל מודול sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>בטל נעילת מודול sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>נעל יעד sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>בטל נעילת יעד sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>רק עמוד נבחר</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>עמוד נבחר וכל {pages} תת-עמודים</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(מהם {deleted} נמחקו, {noaccess} חסומים, ו-{falses} עם סוג עמוד שגוי)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} תת-עמודים עם {deleted} נמחקו ו-{noaccess} לא נגישים)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>עמוד: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>ישנם אזורי משנה מוגבלים המוחרגים מ-sync.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>רקורסיה</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>הוסף לרשימת sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>הגדר עומק רקורסיה</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>נשלח אות ליעד '{target}' עבור sync חדש.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>לא ניתן להודיע ליעד '{target}' עקב שגיאה.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>דולג על שליחת אות ליעד '{target}'. סוג הודעה לא ידוע: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>דולג על שליחת אות ליעד '{target}' כיוון ששליחת אותות מושבתת.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>דולג על שליחת אות ליעד '{target}' עקב הקשר לא תקין. הקשרים מותרים: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>טבלה '{table}' דולגה - אין שינויים מאז ה-sync האחרון.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sync של Assets הופעל</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync הופעל.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync החל - אמור להתעבד תוך 15 דקות הבאות.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>מצב הטבלה עודכן.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>נוצרו {number} קובצי hook URL</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>לא נשמרו נתונים לעיבוד נוסף. תהליך ה-sync הנבחר לא הפיק נתונים כלשהם לסנכרון למערכת היעד.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>מערכת '{target}' נעולה, לכן לא נוצר קובץ url.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>הטבלאות הבאות השתנו, אנא צור קשר עם מנהל ה-TYPO3 שלך:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>מערכת '{system} נעולה לכן לא נוצר עבורה קובץ dump.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>אנא בחר עמוד מעץ העמודים.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>לא ניתן לטעון רשומה עבור העמוד הנבחר: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>סוג העמוד אסור לסנכרון.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>קובץ מצב-טבלה אינו ניתן לכתיבה.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>אין עמודים מסומנים ל-sync.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>כבר קיימת הכנת-sync בתהליך. אנא נסה שוב בעוד כ-5 דקות.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>לא ניתן היה ליצור קובץ zip עבור {file}.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>לא ניתן היה להעביר את הקובץ {file} ל-{target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>אנא בחר כיצד יש לסמן את העמוד.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>העמוד כבר סומן לסנכרון</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>טבלאות MM כמו {tableName} אינן נתמכות עוד.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>ל-FAL יש רשומות פגומות. (רשומות עם uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>בוצע</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>משימות אלו עשויות לקחת זמן, אנא התאזר בסבלנות.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>חדשות</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: משתמשי Backend וקבוצות</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: קבוצות Frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: משימות Scheduler</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: הפניות</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>מצב טבלה</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: עמודים בודדים עם תוכן</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/he.locallang_scheduler.xlf
+++ b/Resources/Private/Language/he.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="he" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>ייבוא סנכרון</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>משימה לייבוא סנכרונים</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>נתיב בו מאוחסנים קבצי הסנכרון.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>נתיב בו מאוחסנים קבצי הכתובות להפעלה.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/hi.locallang.xlf
+++ b/Resources/Private/Language/hi.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="hi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>सिंक मॉड्यूल लॉक करें</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>सक्रिय लॉक की स्थिति में उपयोगकर्ताओं के लिए संदेश</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/hi.locallang_mod.xlf
+++ b/Resources/Private/Language/hi.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="hi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/hi.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/hi.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="hi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>उत्पादन प्रणाली से एकल या एकाधिक लक्ष्य प्रणालियों में सामग्री को समन्वयित करने के लिए एक मॉड्यूल।</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>नया Sync बनाएँ</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Sync बनाएँ</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>पूर्ण sync को बाध्य करें। इस आइटम का पूर्ण sync शुरू किया जाता है, भले ही एक क्रमिक sync संभव हो। यदि संभव हो तो इससे बचना चाहिए।</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>लक्ष्य प्रणाली पर अप्रचलित रिकॉर्ड हटाता है। कोई भी रिकॉर्ड जो छिपे हुए या हटाए गए के रूप में चिह्नित हैं, या जहाँ रिकॉर्ड समाप्ति समय भूतकाल की तारीख है, लक्ष्य प्रणाली पर हटा दिए जाएंगे।</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>तालिका sync स्थिति</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>तालिका</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>अंतिम sync समय</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>अंतिम sync प्रकार</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>अंतिम sync उपयोगकर्ता</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>पूर्ण</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>क्रमिक</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Sync सूची</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>प्रतीक्षारत Syncs</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} फाइल(ें) समन्वयन के लिए प्रतीक्षारत {size}। {oldestFile} से सबसे पुरानी फाइल और इसलिए {minutes} मिनट पुरानी।</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>फाइल</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>आकार</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>आइटम</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>कार्रवाई</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Sync लक्ष्य:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>लक्ष्य '{target}' sync के लिए अक्षम किया गया।</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>लक्ष्य '{target}' sync के लिए सक्षम किया गया।</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>sync मॉड्यूल को लॉक करें</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>sync मॉड्यूल को अनलॉक करें</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>sync लक्ष्य को लॉक करें: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>sync लक्ष्य को अनलॉक करें: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>केवल चयनित पृष्ठ</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>चयनित पृष्ठ और सभी {pages} उप-पृष्ठ</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(जिनमें से {deleted} हटाए गए हैं, {noaccess} अवरुद्ध हैं, और {falses} में गलत पृष्ठ प्रकार है)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} उप-पृष्ठ जिनमें से {deleted} हटाए गए और {noaccess} अप्राप्य हैं)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>पृष्ठ: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>प्रतिबंधित उप-क्षेत्र हैं जो sync से बाहर रखे गए हैं।</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>पुनरावर्तन</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>sync सूची में जोड़ें</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>पुनरावर्तन गहराई सेट करें</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>नए sync के लिए '{target}' लक्ष्य को संकेत दिया गया।</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>त्रुटि के कारण लक्ष्य '{target}' को सूचित नहीं किया जा सका।</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>'{target}' लक्ष्य को संकेत देना छोड़ा गया। अज्ञात सूचना प्रकार: '{notify_type}'।</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>संकेत अक्षम होने के कारण '{target}' लक्ष्य को संकेत देना छोड़ा गया।</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>अमान्य संदर्भ के कारण '{target}' लक्ष्य को संकेत देना छोड़ा गया। अनुमत संदर्भ: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>तालिका '{table}' छोड़ी गई - अंतिम sync के बाद से कोई परिवर्तन नहीं।</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Assets का Sync शुरू किया गया</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync शुरू किया गया।</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync शुरू हो गया - अगले 15 मिनट में संसाधित किया जाना चाहिए।</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>तालिका स्थिति अपडेट की गई।</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number} hook URL फाइलें बनाई गईं</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>आगे की प्रक्रिया के लिए कोई डेटा डंप नहीं किया गया। चयनित sync प्रक्रिया ने लक्ष्य प्रणाली में sync करने के लिए कोई डेटा उत्पन्न नहीं किया।</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>प्रणाली '{target}' लॉक है, इसलिए कोई url फाइल नहीं बनाई गई।</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>निम्नलिखित तालिकाएँ बदल गई हैं, कृपया अपने TYPO3 व्यवस्थापक से संपर्क करें:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>प्रणाली '{system} लॉक है इसलिए इसके लिए कोई dump-file नहीं बनाई गई।</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>कृपया पृष्ठ ट्री से एक पृष्ठ चुनें।</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>चयनित पृष्ठ के लिए रिकॉर्ड लोड नहीं किया जा सका: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>पृष्ठ प्रकार को समन्वयित नहीं किया जा सकता।</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>तालिका-स्थिति-फाइल लिखने योग्य नहीं है।</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>sync करने के लिए कोई पृष्ठ चिह्नित नहीं हैं।</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>पहले से ही एक sync-तैयारी प्रगति में है। कृपया लगभग 5 मिनट में पुनः प्रयास करें।</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>{file} के लिए Zipfile नहीं बनाई जा सकी।</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>फाइल {file} को {target} में नहीं ले जाया जा सका।</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>कृपया चुनें कि पृष्ठ को कैसे चिह्नित किया जाना चाहिए।</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>पृष्ठ को पहले से ही समन्वयन के लिए चिह्नित किया गया है</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>{tableName} जैसी MM तालिकाएँ अब समर्थित नहीं हैं।</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL में दूषित प्रविष्टियाँ हैं। (uid_foreign = 0 वाली प्रविष्टियाँ)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>पूर्ण</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>इन कार्यों में कुछ समय लग सकता है, कृपया धैर्य रखें।</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>समाचार</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend उपयोगकर्ता और समूह</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend समूह</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Scheduler कार्य</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: रीडायरेक्ट्स</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>तालिका स्थिति</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: सामग्री वाले एकल पृष्ठ</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/hi.locallang_scheduler.xlf
+++ b/Resources/Private/Language/hi.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="hi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>सिंक आयात</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>सिंक आयात करने का कार्य</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>पथ जहाँ सिंक फ़ाइलें संग्रहीत हैं।</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>पथ जहाँ निष्पादित करने के लिए URL फ़ाइलें संग्रहीत हैं।</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/hu.locallang.xlf
+++ b/Resources/Private/Language/hu.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="hu" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Szinkronizálási modul zárolása</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Üzenet a felhasználóknak aktív zárolás esetén</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/hu.locallang_mod.xlf
+++ b/Resources/Private/Language/hu.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="hu" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/hu.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/hu.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="hu" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Modul a tartalom szinkronizálásához egy éles rendszerből egy vagy több célrendszerbe.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Új Sync létrehozása</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Sync létrehozása</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Teljes szinkronizálás kényszerítése. Az elem teljes szinkronizálása akkor is elindul, ha növekményes szinkronizálás lehetséges lenne. Ezt lehetőség szerint kerülni kell.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Elavult rekordok törlése a célrendszeren. Minden rejtettnek vagy töröltnek jelölt rekord, valamint azok, amelyek végideje múltbeli dátum, törlődnek a célrendszeren.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Tábla szinkronizálási állapot</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tábla</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Utolsó szinkronizálás ideje</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Utolsó szinkronizálás típusa</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Utolsó szinkronizálás felhasználója</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>teljes</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>növekményes</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Sync lista</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Várakozó Syncs</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} fájl vár szinkronizálásra {size}. A legrégebbi fájl {oldestFile} óta, ezért {minutes} perc régi.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Fájl</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Méret</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Elem</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Művelet</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Sync célrendszer:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>'{target}' célrendszer letiltva a sync számára.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>'{target}' célrendszer engedélyezve a sync számára.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Sync modul zárolása</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Sync modul feloldása</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Sync célrendszer zárolása: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Sync célrendszer feloldása: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Csak a kiválasztott oldal</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Kiválasztott oldal és az összes {pages} aloldal</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(amelyből {deleted} törölve, {noaccess} zárolt, és {falses} hibás oldaltípusú)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} aloldal, {deleted} törölve és {noaccess} nem elérhető)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Oldal: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Vannak korlátozott területek, amelyek ki vannak zárva a sync-ből.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekurzió</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Hozzáadás a sync listához</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Rekurziós mélység beállítása</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>'{target}' célrendszer értesítve új sync-ről.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>'{target}' célrendszert nem lehetett értesíteni hiba miatt.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>'{target}' célrendszer értesítése kihagyva. Ismeretlen értesítési típus: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>'{target}' célrendszer értesítése kihagyva, mert az értesítés le van tiltva.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>'{target}' célrendszer értesítése kihagyva érvénytelen kontextus miatt. Engedélyezett kontextusok: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>'{table}' tábla kihagyva - nincs változás az utolsó sync óta.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Assets Sync elindítva</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync elindítva.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync elindult - a következő 15 percen belül feldolgozásra kerül.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Táblaállapot frissítve.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number} hook URL fájl létrehozva</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Nincs adat mentve további feldolgozásra. A kiválasztott sync folyamat nem hozott létre adatot a célrendszerbe történő szinkronizálásra.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>'{target}' rendszer zárolva van, ezért nem jön létre url fájl.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>A következő táblák megváltoztak, kérjük, vegye fel a kapcsolatot a TYPO3 rendszergazdával:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>'{system} rendszer zárolva van, ezért nem jön létre dump-fájl.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Kérjük, válasszon egy oldalt az oldalfából.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Nem sikerült betölteni a kiválasztott oldal rekordjait: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Az oldaltípus nem szinkronizálható.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>A táblaállapot-fájl nem írható.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Nincsenek sync-re megjelölt oldalak.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Már folyamatban van egy sync-előkészítés. Kérjük, próbálja újra körülbelül 5 perc múlva.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>A(z) {file} zip fájl nem hozható létre.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>A(z) {file} fájl nem helyezhető át ide: {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Kérjük, válassza ki, hogyan legyen megjelölve az oldal.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Az oldal már meg van jelölve szinkronizálásra</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Az MM táblák, mint például {tableName}, már nem támogatottak.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>A FAL sérült bejegyzéseket tartalmaz. (uid_foreign = 0 értékű bejegyzések)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>kész</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Ez a feladat eltarthat egy ideig, kérjük, legyen türelemmel.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Hírek</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend felhasználók és csoportok</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend csoportok</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Scheduler feladatok</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Átirányítások</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Táblaállapot</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Egyes oldalak tartalommal</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/hu.locallang_scheduler.xlf
+++ b/Resources/Private/Language/hu.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="hu" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Szinkronizálás importálása</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Feladat a szinkronizálások importálásához</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Elérési út, ahol a szinkronizálási fájlok tárolva vannak.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Elérési út, ahol a végrehajtandó URL fájlok tárolva vannak.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/id.locallang.xlf
+++ b/Resources/Private/Language/id.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="id" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Kunci modul sinkronisasi</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Pesan untuk pengguna jika kunci aktif</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/id.locallang_mod.xlf
+++ b/Resources/Private/Language/id.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="id" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/id.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/id.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="id" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Modul untuk menyinkronkan konten dari sistem produksi ke satu atau beberapa sistem target.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Buat Sync baru</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Buat Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Paksa sync penuh. Sync penuh untuk item ini akan dimulai meskipun sync inkremental dimungkinkan. Ini sebaiknya dihindari jika memungkinkan.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Hapus rekaman usang pada sistem target. Semua rekaman yang ditandai sebagai tersembunyi atau dihapus, atau yang waktu akhir rekamannya adalah tanggal di masa lalu, akan dihapus pada sistem target.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Status sync tabel</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabel</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Waktu sync terakhir</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Jenis sync terakhir</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Pengguna sync terakhir</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>penuh</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>inkremental</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Daftar Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Sync Menunggu</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} file menunggu sinkronisasi {size}. File tertua dari {oldestFile} dan berusia {minutes} menit.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>File</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Ukuran</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Item</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Tindakan</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Target sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Target '{target}' dinonaktifkan untuk sync.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Target '{target}' diaktifkan untuk sync.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Kunci modul sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Buka kunci modul sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Kunci target sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Buka kunci target sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Hanya halaman terpilih</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Halaman terpilih dan semua {pages} sub halaman</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(di mana {deleted} dihapus, {noaccess} diblokir, dan {falses} memiliki jenis halaman yang salah)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} sub halaman dengan {deleted} dihapus dan {noaccess} tidak dapat diakses)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Halaman: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Ada subarea terbatas yang dikecualikan dari sync.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekursi</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Tambahkan ke daftar sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Atur kedalaman rekursi</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Mengirim sinyal ke target '{target}' untuk sync baru.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Target '{target}' tidak dapat diberi tahu karena terjadi kesalahan.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Melewatkan pengiriman sinyal ke target '{target}'. Jenis notifikasi tidak dikenal: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Melewatkan pengiriman sinyal ke target '{target}' karena pengiriman sinyal dinonaktifkan.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Melewatkan pengiriman sinyal ke target '{target}' karena konteks tidak valid. Konteks yang diizinkan: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabel '{table}' dilewati - tidak ada perubahan sejak sync terakhir.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sync Assets dimulai</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync dimulai.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync dimulai - akan diproses dalam 15 menit ke depan.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Status tabel diperbarui.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Dibuat {number} file URL hook</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Tidak ada data yang di-dump untuk pemrosesan lebih lanjut. Proses sync yang dipilih tidak menghasilkan data untuk disinkronkan ke sistem target.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Sistem '{target}' terkunci, jadi tidak ada file url yang dibuat.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Tabel berikut telah berubah, silakan hubungi admin TYPO3 Anda:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Sistem '{system} terkunci sehingga tidak ada file dump yang dibuat untuk sistem tersebut.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Silakan pilih halaman dari pohon halaman.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Tidak dapat memuat rekaman untuk halaman yang dipilih: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Jenis halaman tidak boleh disinkronkan.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>File status tabel tidak dapat ditulis.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Tidak ada halaman yang ditandai untuk sync.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Sudah ada persiapan sync yang sedang berlangsung. Silakan coba lagi dalam sekitar 5 menit.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>File zip untuk {file} tidak dapat dibuat.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>File {file} tidak dapat dipindahkan ke {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Silakan pilih bagaimana halaman harus ditandai.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Halaman sudah ditandai untuk sinkronisasi</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Tabel MM seperti {tableName} tidak lagi didukung.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL memiliki entri yang rusak. (Entri dengan uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>selesai</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Tugas ini dapat memakan waktu, mohon bersabar.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Berita</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Pengguna dan grup backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Grup frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Tugas Scheduler</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirects</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Status tabel</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Halaman tunggal dengan konten</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/id.locallang_scheduler.xlf
+++ b/Resources/Private/Language/id.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="id" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Impor sinkronisasi</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Tugas untuk mengimpor sinkronisasi</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Jalur tempat file sinkronisasi disimpan.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Jalur tempat file URL yang akan dieksekusi disimpan.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/it.locallang.xlf
+++ b/Resources/Private/Language/it.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="it" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Blocca modulo di sincronizzazione</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Messaggio per gli utenti in caso di blocco attivo</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/it.locallang_mod.xlf
+++ b/Resources/Private/Language/it.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="it" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/it.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/it.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="it" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Un modulo per sincronizzare i contenuti da un sistema di produzione a uno o più sistemi di destinazione.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Crea nuovo Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Crea Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Forza un sync completo. Viene avviato un sync completo di questo elemento anche se è possibile un sync incrementale. Questo dovrebbe essere evitato se possibile.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Elimina i record obsoleti sul sistema di destinazione. Tutti i record contrassegnati come nascosti o eliminati, o in cui l'ora di fine del record è una data nel passato, verranno eliminati sul sistema di destinazione.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Stato sync tabella</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabella</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Ora dell'ultimo sync</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Tipo di ultimo sync</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Utente ultimo sync</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>completo</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>incrementale</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Elenco Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Sync in attesa</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} file in attesa di sincronizzazione {size}. Il file più vecchio da {oldestFile} e quindi di {minutes} minuti.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>File</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Dimensione</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Elemento</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Azione</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Destinazione sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Destinazione '{target}' disabilitata per sync.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Destinazione '{target}' abilitata per sync.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Blocca modulo sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Sblocca modulo sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Blocca destinazione sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Sblocca destinazione sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Solo pagina selezionata</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Pagina selezionata e tutte le {pages} sottopagine</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(di cui {deleted} sono eliminate, {noaccess} sono bloccate e {falses} hanno il tipo di pagina sbagliato)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} sottopagine con {deleted} eliminate e {noaccess} inaccessibili)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Pagina: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Ci sono sottoaree riservate escluse dal sync.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Ricorsione</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Aggiungi all'elenco sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Imposta profondità ricorsione</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Segnalata la destinazione '{target}' per nuovo sync.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>La destinazione '{target}' non può essere notificata a causa di un errore.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Saltata la segnalazione alla destinazione '{target}'. Tipo di notifica sconosciuto: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Saltata la segnalazione alla destinazione '{target}' perché la segnalazione è disabilitata.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Saltata la segnalazione alla destinazione '{target}' a causa di contesto non valido. Contesti consentiti: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabella '{table}' saltata - nessuna modifica dall'ultimo sync.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sync Assets avviato</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync avviato.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync avviato - dovrebbe essere elaborato entro i prossimi 15 minuti.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Stato della tabella aggiornato.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Creati {number} file URL hook</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Nessun dato esportato per ulteriore elaborazione. Il processo sync selezionato non ha prodotto dati da sincronizzare sul sistema di destinazione.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Il sistema '{target}' è bloccato, quindi non viene creato alcun file url.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Le seguenti tabelle sono state modificate, contatta il tuo amministratore TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Il sistema '{system} è bloccato quindi non viene creato alcun file dump per esso.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Seleziona una pagina dall'albero delle pagine.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Impossibile caricare il record per la pagina selezionata: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Il tipo di pagina non deve essere sincronizzato.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Il file di stato della tabella non è scrivibile.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Non ci sono pagine contrassegnate per sync.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>C'è già una preparazione sync in corso. Riprova tra circa 5 minuti.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Il file zip per {file} non può essere creato.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Il file {file} non può essere spostato in {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Seleziona come deve essere contrassegnata la pagina.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>La pagina è già stata contrassegnata per la sincronizzazione</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Le tabelle MM come {tableName} non sono più supportate.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL ha voci corrotte. (Voci con uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>fatto</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Questa operazione può richiedere del tempo, si prega di essere pazienti.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Notizie</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Utenti e gruppi backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Gruppi frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Operazioni Scheduler</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirects</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Stato della tabella</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Pagine singole con contenuto</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/it.locallang_scheduler.xlf
+++ b/Resources/Private/Language/it.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="it" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Importazione sincronizzazione</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Attività per importare le sincronizzazioni</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Percorso in cui sono memorizzati i file di sincronizzazione.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Percorso in cui sono memorizzati i file URL da eseguire.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ja.locallang.xlf
+++ b/Resources/Private/Language/ja.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ja" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>同期モジュールをロック</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>アクティブなロック時のユーザーへのメッセージ</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ja.locallang_mod.xlf
+++ b/Resources/Private/Language/ja.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ja" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/ja.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/ja.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ja" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>本番システムから単一または複数のターゲットシステムにコンテンツを同期するためのモジュールです。</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>新しいSyncを作成</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Syncを作成</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>完全同期を強制します。増分同期が可能な場合でも、このアイテムの完全同期が開始されます。可能であれば避けるべきです。</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>ターゲットシステム上の古いレコードを削除します。非表示または削除としてマークされているレコード、またはレコードの終了時刻が過去の日付であるレコードは、ターゲットシステムで削除されます。</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>テーブル同期ステータス</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>テーブル</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>最終同期時刻</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>最終同期タイプ</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>最終同期ユーザー</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>完全</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>増分</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Syncリスト</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>待機中のSync</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files}個のファイルが同期待機中です{size}。最も古いファイルは{oldestFile}からで、{minutes}分経過しています。</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>ファイル</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>サイズ</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>アイテム</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>操作</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Syncターゲット:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>ターゲット'{target}'は同期が無効になっています。</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>ターゲット'{target}'は同期が有効になっています。</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Syncモジュールをロック</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Syncモジュールのロックを解除</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Syncターゲットをロック: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Syncターゲットのロックを解除: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>選択されたページのみ</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>選択されたページとすべての{pages}個のサブページ</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(うち{deleted}個が削除、{noaccess}個がブロック、{falses}個が誤ったページタイプ)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages}個のサブページのうち{deleted}個が削除、{noaccess}個がアクセス不可)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>ページ: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>同期から除外されている制限付きサブエリアがあります。</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>再帰</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Syncリストに追加</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>再帰の深さを設定</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>新しい同期のためにターゲット'{target}'に信号を送信しました。</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>エラーのため、ターゲット'{target}'に通知できませんでした。</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>ターゲット'{target}'への信号送信をスキップしました。不明な通知タイプ: '{notify_type}'。</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>信号送信が無効になっているため、ターゲット'{target}'への信号送信をスキップしました。</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>無効なコンテキストのため、ターゲット'{target}'への信号送信をスキップしました。許可されたコンテキスト: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>テーブル'{table}'をスキップしました - 最終同期以降の変更がありません。</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sync Assetsを開始しました</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Syncを開始しました。</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Syncを開始しました - 今後15分以内に処理されます。</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>テーブルの状態を更新しました。</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number}個のフックURLファイルを作成しました</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>さらなる処理のためのデータがダンプされませんでした。選択された同期プロセスは、ターゲットシステムに同期するデータを生成しませんでした。</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>システム'{target}'がロックされているため、URLファイルは作成されません。</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>次のテーブルが変更されました。TYPO3管理者に連絡してください:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>システム'{system}がロックされているため、ダンプファイルは作成されません。</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>ページツリーからページを選択してください。</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>選択されたページのレコードを読み込めませんでした: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>このページタイプは同期できません。</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>テーブル状態ファイルに書き込みができません。</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>同期用にマークされたページがありません。</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>既に同期準備が進行中です。約5分後に再試行してください。</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>{file}のZIPファイルを作成できませんでした。</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>ファイル{file}を{target}に移動できませんでした。</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>ページをマークする方法を選択してください。</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>このページは既に同期用にマークされています</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>{tableName}のようなMMテーブルはサポートされなくなりました。</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FALに破損したエントリがあります。(uid_foreign = 0のエントリ)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>完了</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>このタスクには時間がかかる場合があります。しばらくお待ちください。</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>ニュース</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: バックエンドユーザーとグループ</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: フロントエンドグループ</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Schedulerタスク</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirects</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>テーブル状態</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: コンテンツを含む単一ページ</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ja.locallang_scheduler.xlf
+++ b/Resources/Private/Language/ja.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ja" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>同期インポート</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>同期をインポートするタスク</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>同期ファイルが保存されているパス。</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>実行するURLファイルが保存されているパス。</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ko.locallang.xlf
+++ b/Resources/Private/Language/ko.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ko" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>동기화 모듈 잠금</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>활성 잠금 시 사용자를 위한 메시지</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ko.locallang_mod.xlf
+++ b/Resources/Private/Language/ko.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ko" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/ko.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/ko.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ko" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>프로덕션 시스템에서 하나 또는 여러 대상 시스템으로 콘텐츠를 동기화하는 모듈입니다.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>새 Sync 생성</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Sync 생성</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>전체 동기화를 강제합니다. 증분 동기화가 가능한 경우에도 이 항목의 전체 동기화가 시작됩니다. 가능하면 피해야 합니다.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>대상 시스템에서 오래된 레코드를 삭제합니다. 숨김 또는 삭제로 표시된 레코드나 종료 시간이 과거인 레코드는 대상 시스템에서 삭제됩니다.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>테이블 동기화 상태</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>테이블</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>마지막 동기화 시간</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>마지막 동기화 유형</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>마지막 동기화 사용자</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>전체</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>증분</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Sync 목록</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>대기 중인 Sync</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files}개 파일이 동기화를 기다리고 있습니다 {size}. 가장 오래된 파일은 {oldestFile}이며 {minutes}분 경과했습니다.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>파일</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>크기</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>항목</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>작업</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Sync 대상:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>대상 '{target}'의 동기화가 비활성화되었습니다.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>대상 '{target}'의 동기화가 활성화되었습니다.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>동기화 모듈 잠금</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>동기화 모듈 잠금 해제</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>동기화 대상 잠금: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>동기화 대상 잠금 해제: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>선택한 페이지만</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>선택한 페이지 및 모든 {pages}개 하위 페이지</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(그 중 {deleted}개 삭제됨, {noaccess}개 차단됨, {falses}개 잘못된 페이지 유형)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages}개 하위 페이지, {deleted}개 삭제됨, {noaccess}개 접근 불가)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>페이지: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>동기화에서 제외된 제한 영역이 있습니다.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>재귀</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>동기화 목록에 추가</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>재귀 깊이 설정</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>새 동기화를 위해 '{target}' 대상에 신호를 보냈습니다.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>오류로 인해 대상 '{target}'에 알림을 보낼 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>'{target}' 대상 신호 전송을 건너뛰었습니다. 알 수 없는 알림 유형: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>신호 전송이 비활성화되어 '{target}' 대상 신호 전송을 건너뛰었습니다.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>잘못된 컨텍스트로 인해 '{target}' 대상 신호 전송을 건너뛰었습니다. 허용된 컨텍스트: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>테이블 '{table}' 건너뜀 - 마지막 동기화 이후 변경 사항 없음.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Assets 동기화 시작됨</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>동기화가 시작되었습니다.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>동기화가 시작되었습니다 - 다음 15분 내에 처리될 예정입니다.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>테이블 상태가 업데이트되었습니다.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number}개의 훅 URL 파일이 생성되었습니다</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>추가 처리를 위해 덤프된 데이터가 없습니다. 선택한 동기화 프로세스는 대상 시스템과 동기화할 데이터를 생성하지 않았습니다.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>시스템 '{target}'이 잠겨 있어 URL 파일이 생성되지 않습니다.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>다음 테이블이 변경되었습니다. TYPO3 관리자에게 문의하세요:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>시스템 '{system}'이 잠겨 있어 덤프 파일이 생성되지 않습니다.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>페이지 트리에서 페이지를 선택하세요.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>선택한 페이지의 레코드를 로드할 수 없습니다: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>이 페이지 유형은 동기화할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>테이블 상태 파일을 쓸 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>동기화할 페이지가 표시되지 않았습니다.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>이미 동기화 준비가 진행 중입니다. 약 5분 후에 다시 시도하세요.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>{file}에 대한 압축 파일을 생성할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>파일 {file}을(를) {target}(으)로 이동할 수 없습니다.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>페이지를 표시할 방법을 선택하세요.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>페이지가 이미 동기화용으로 표시되었습니다</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>{tableName}과(와) 같은 MM 테이블은 더 이상 지원되지 않습니다.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL에 손상된 항목이 있습니다. (uid_foreign = 0인 항목)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>완료</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>이 작업은 시간이 걸릴 수 있습니다. 잠시 기다려 주세요.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>뉴스</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: 백엔드 사용자 및 그룹</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: 프론트엔드 그룹</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: 스케줄러 작업</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: 리다이렉트</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>테이블 상태</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: 콘텐츠가 있는 단일 페이지</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ko.locallang_scheduler.xlf
+++ b/Resources/Private/Language/ko.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ko" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>동기화 가져오기</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>동기화를 가져오는 작업</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>동기화 파일이 저장된 경로.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>실행할 URL 파일이 저장된 경로.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-    <file source-language="en" datatype="plaintext" original="messages" date="2020-11-11T12:00:00Z" product-name="nr-sync">
-        <header/>
-        <body>
-            <trans-unit id="lock.label">
-                <source>Lock sync module</source>
-            </trans-unit>
-            <trans-unit id="lock.message">
-                <source>Message for users in case of active lock</source>
-            </trans-unit>
-        </body>
-    </file>
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+    <body>
+      <trans-unit id="lock.label">
+        <source>Lock sync module</source>
+      </trans-unit>
+      <trans-unit id="lock.message">
+        <source>Message for users in case of active lock</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -1,18 +1,16 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
-<xliff version="1.0">
-    <file source-language="en" datatype="plaintext" original="messages" date="2024-01-01T00:00:00Z"
-          product-name="nr_sync">
-        <header/>
-        <body>
-            <trans-unit id="mlang_tabs_tab">
-                <source>Netresearch</source>
-            </trans-unit>
-            <trans-unit id="mlang_labels_tablabel">
-                <source>Netresearch</source>
-            </trans-unit>
-            <trans-unit id="mlang_labels_tabdescr">
-                <source>Netresearch</source>
-            </trans-unit>
-        </body>
-    </file>
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+    <body>
+      <trans-unit id="mlang_tabs_tab">
+        <source>Netresearch</source>
+      </trans-unit>
+      <trans-unit id="mlang_labels_tablabel">
+        <source>Netresearch</source>
+      </trans-unit>
+      <trans-unit id="mlang_labels_tabdescr">
+        <source>Netresearch</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Language/nl.locallang.xlf
+++ b/Resources/Private/Language/nl.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="nl" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Synchronisatiemodule vergrendelen</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Bericht voor gebruikers bij actieve vergrendeling</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/nl.locallang_mod.xlf
+++ b/Resources/Private/Language/nl.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="nl" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/nl.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/nl.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="nl" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Een module voor het synchroniseren van inhoud van een productiesysteem naar één of meerdere doelsystemen.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Nieuwe Sync aanmaken</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Sync aanmaken</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Forceer een volledige synchronisatie. Een volledige synchronisatie van dit item wordt gestart, zelfs als een incrementele synchronisatie mogelijk is. Dit moet indien mogelijk worden vermeden.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Verwijdert verouderde records op het doelsysteem. Alle records die zijn gemarkeerd als verborgen of verwijderd, of waarvan de eindtijd een datum in het verleden is, worden verwijderd op het doelsysteem.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Tabelsynchronisatiestatus</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabel</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Laatste synchronisatietijd</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Laatste synchronisatietype</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Laatste synchronisatiegebruiker</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>volledig</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>incrementeel</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Synclijst</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Wachtende Syncs</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} bestand(en) wachten op synchronisatie {size}. Oudste bestand van {oldestFile} en daarom {minutes} minuten oud.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Bestand</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Grootte</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Item</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Actie</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Syncdoel:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Doel '{target}' uitgeschakeld voor synchronisatie.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Doel '{target}' ingeschakeld voor synchronisatie.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Syncmodule vergrendelen</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Syncmodule ontgrendelen</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Syncdoel vergrendelen: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Syncdoel ontgrendelen: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Alleen geselecteerde pagina</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Geselecteerde pagina en alle {pages} subpagina's</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(waarvan {deleted} verwijderd, {noaccess} geblokkeerd en {falses} verkeerd paginatype hebben)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} subpagina's met {deleted} verwijderd en {noaccess} ontoegankelijk)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Pagina: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Er zijn beperkte subgebieden die zijn uitgesloten van synchronisatie.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Recursie</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Toevoegen aan synclijst</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Recursiediepte instellen</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Doel '{target}' gesignaleerd voor nieuwe synchronisatie.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Doel '{target}' kon niet worden geïnformeerd vanwege een fout.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Signaleren van doel '{target}' overgeslagen. Onbekend notificatietype: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Signaleren van doel '{target}' overgeslagen omdat signalering is uitgeschakeld.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Signaleren van doel '{target}' overgeslagen vanwege ongeldige context. Toegestane contexten: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabel '{table}' overgeslagen - geen wijzigingen sinds laatste synchronisatie.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Assets-synchronisatie gestart</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Synchronisatie gestart.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Synchronisatie gestart - moet binnen 15 minuten worden verwerkt.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Tabelstatus bijgewerkt.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number} hook-URL-bestanden aangemaakt</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Geen gegevens gedumpt voor verdere verwerking. Het geselecteerde synchronisatieproces heeft geen gegevens geproduceerd om te synchroniseren met het doelsysteem.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Systeem '{target}' is vergrendeld, dus er wordt geen URL-bestand aangemaakt.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Volgende tabellen zijn gewijzigd, neem contact op met uw TYPO3-beheerder:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Systeem '{system}' is vergrendeld, dus er wordt geen dump-bestand voor aangemaakt.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Selecteer een pagina uit de paginaboom.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Kan record voor geselecteerde pagina niet laden: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Het paginatype mag niet worden gesynchroniseerd.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Tabelstatusbestand is niet beschrijfbaar.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Er zijn geen pagina's gemarkeerd om te synchroniseren.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Er is al een synchronisatievoorbereiding aan de gang. Probeer het over ongeveer 5 minuten opnieuw.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zipbestand voor {file} kon niet worden aangemaakt.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Bestand {file} kon niet worden verplaatst naar {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Selecteer hoe de pagina moet worden gemarkeerd.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>De pagina is al gemarkeerd voor synchronisatie</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM-tabellen zoals {tableName} worden niet meer ondersteund.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL heeft beschadigde items. (Items met uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>klaar</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Deze taak kan enige tijd duren, wees geduldig.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Nieuws</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend-gebruikers en groepen</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend-groepen</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Scheduler-taken</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Omleidingen</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Tabelstatus</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Enkele pagina's met inhoud</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/nl.locallang_scheduler.xlf
+++ b/Resources/Private/Language/nl.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="nl" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Synchronisatie importeren</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Taak om synchronisaties te importeren</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Pad waar de synchronisatiebestanden zijn opgeslagen.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Pad waar de uit te voeren URL-bestanden zijn opgeslagen.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/no.locallang.xlf
+++ b/Resources/Private/Language/no.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="no" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Lås synkroniseringsmodul</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Melding til brukere ved aktiv lås</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/no.locallang_mod.xlf
+++ b/Resources/Private/Language/no.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="no" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/no.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/no.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="no" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>En modul for synkronisering av innhold fra et produksjonssystem til ett eller flere målsystemer.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Opprett ny Sync</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Opprett Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Tving full synkronisering. En full synkronisering av dette elementet starter selv om en inkrementell synkronisering er mulig. Dette bør unngås hvis mulig.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Sletter utdaterte poster på målsystemet. Alle poster som er merket som skjult eller slettet, eller der sluttidspunktet er en dato i fortiden, vil bli slettet på målsystemet.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Tabellsynkroniseringsstatus</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabell</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Siste synkroniseringstid</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Siste synkroniseringstype</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Siste synkroniseringsbruker</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>full</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>inkrementell</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Synkroniseringsliste</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Ventende synkroniseringer</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} fil(er) venter på synkronisering {size}. Eldste fil fra {oldestFile} og derfor {minutes} minutter gammel.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Fil</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Størrelse</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Element</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Handling</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Synkroniseringsmål:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Mål '{target}' deaktivert for synkronisering.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Mål '{target}' aktivert for synkronisering.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Lås synkroniseringsmodul</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Lås opp synkroniseringsmodul</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Lås synkroniseringsmål: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Lås opp synkroniseringsmål: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Kun valgt side</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Valgt side og alle {pages} undersider</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(hvorav {deleted} er slettet, {noaccess} er blokkert, og {falses} har feil sidetype)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} undersider med {deleted} slettet og {noaccess} utilgjengelig)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Side: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Det finnes begrensede underområder som er ekskludert fra synkronisering.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekursjon</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Legg til i synkroniseringsliste</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Angi rekursjonsdybde</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Signaliserte mål '{target}' for ny synkronisering.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Mål '{target}' kunne ikke varsles på grunn av en feil.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Hoppet over signalisering av mål '{target}'. Ukjent varslingstype: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Hoppet over signalisering av mål '{target}' på grunn av deaktivert signalisering.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Hoppet over signalisering av mål '{target}' på grunn av ugyldig kontekst. Tillatte kontekster: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabell '{table}' hoppet over - ingen endringer siden siste synkronisering.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Assets-synkronisering startet</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Synkronisering startet.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Synkronisering startet - skal behandles innen neste 15 minutter.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Oppdatert tabellstatus.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Opprettet {number} hook-URL-filer</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Ingen data dumpet for videre behandling. Den valgte synkroniseringsprosessen produserte ikke noen data som skal synkroniseres til målsystemet.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>System '{target}' er låst, så ingen URL-fil opprettes.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Følgende tabeller er endret, vennligst kontakt TYPO3-administratoren din:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>System '{system}' er låst, så ingen dump-fil opprettes for det.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Vennligst velg en side fra sidetreet.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Kunne ikke laste post for valgt side: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Sidetypen må ikke synkroniseres.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Tabellstatusfil er ikke skrivbar.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Det er ingen sider merket for synkronisering.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Det er allerede en synkroniseringsforberedelse i gang. Vennligst prøv igjen om ca. 5 minutter.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zip-fil for {file} kunne ikke opprettes.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Fil {file} kunne ikke flyttes til {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Vennligst velg hvordan siden skal merkes.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Siden er allerede merket for synkronisering</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM-tabeller som {tableName} støttes ikke lenger.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL har ødelagte oppføringer. (Oppføringer med uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>ferdig</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Denne oppgaven kan ta litt tid, vennligst vær tålmodig.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Nyheter</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend-brukere og grupper</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend-grupper</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Planleggeroppgaver</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Omdirigeringer</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Tabellstatus</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Enkeltsider med innhold</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/no.locallang_scheduler.xlf
+++ b/Resources/Private/Language/no.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="no" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Sync-import</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Oppgave for å importere synkroniseringer</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Sti der synkroniseringsfilene er lagret.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Sti der URL-filene som skal kjøres er lagret.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/pl.locallang.xlf
+++ b/Resources/Private/Language/pl.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="pl" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Zablokuj moduł synchronizacji</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Wiadomość dla użytkowników w przypadku aktywnej blokady</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/pl.locallang_mod.xlf
+++ b/Resources/Private/Language/pl.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="pl" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/pl.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/pl.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="pl" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Moduł do synchronizacji treści z systemu produkcyjnego do pojedynczego lub wielu systemów docelowych.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Utwórz nową synchronizację</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Utwórz synchronizację</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Wymuś pełną synchronizację. Pełna synchronizacja tego elementu zostanie zainicjowana, nawet jeśli możliwa jest synchronizacja przyrostowa. Należy tego unikać, jeśli to możliwe.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Usuwa przestarzałe rekordy w systemie docelowym. Wszystkie rekordy oznaczone jako ukryte lub usunięte, lub których czas zakończenia jest datą z przeszłości, zostaną usunięte w systemie docelowym.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Status synchronizacji tabeli</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabela</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Czas ostatniej synchronizacji</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Typ ostatniej synchronizacji</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Użytkownik ostatniej synchronizacji</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>pełna</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>przyrostowa</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Lista synchronizacji</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Oczekujące synchronizacje</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} plik(ów) oczekuje na synchronizację {size}. Najstarszy plik z {oldestFile}, czyli {minutes} minut temu.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Plik</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Rozmiar</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Element</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Akcja</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Cel synchronizacji:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Cel '{target}' wyłączony dla synchronizacji.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Cel '{target}' włączony dla synchronizacji.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Zablokuj moduł synchronizacji</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Odblokuj moduł synchronizacji</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Zablokuj cel synchronizacji: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Odblokuj cel synchronizacji: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Tylko wybrana strona</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Wybrana strona i wszystkie {pages} podstrony</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(z czego {deleted} jest usuniętych, {noaccess} jest zablokowanych, a {falses} ma nieprawidłowy typ strony)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} podstron, z czego {deleted} usuniętych i {noaccess} niedostępnych)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Strona: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Istnieją ograniczone podobszary, które są wykluczone z synchronizacji.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekursja</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Dodaj do listy synchronizacji</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Ustaw głębokość rekursji</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Wysłano sygnał do celu '{target}' dla nowej synchronizacji.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Cel '{target}' nie mógł zostać powiadomiony z powodu błędu.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Pominięto sygnalizację celu '{target}'. Nieznany typ powiadomienia: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Pominięto sygnalizację celu '{target}' z powodu wyłączonej sygnalizacji.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Pominięto sygnalizację celu '{target}' z powodu nieprawidłowego kontekstu. Dozwolone konteksty: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabela '{table}' pominięta - brak zmian od ostatniej synchronizacji.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Zainicjowano synchronizację Assets</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Zainicjowano synchronizację.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Synchronizacja rozpoczęta - powinna zostać przetworzona w ciągu następnych 15 minut.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Zaktualizowano stan tabeli.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Utworzono {number} plików URL hook</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Brak danych do dalszego przetwarzania. Wybrany proces synchronizacji nie wygenerował żadnych danych do synchronizacji z systemem docelowym.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>System '{target}' jest zablokowany, więc plik url nie został utworzony.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Następujące tabele uległy zmianie, skontaktuj się z administratorem TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>System '{system} jest zablokowany, więc nie utworzono dla niego pliku zrzutu.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Proszę wybrać stronę z drzewa stron.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Nie można załadować rekordu dla wybranej strony: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Typ strony nie może być synchronizowany.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Plik stanu tabeli nie jest zapisywalny.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Brak stron oznaczonych do synchronizacji.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Trwa już przygotowanie synchronizacji. Spróbuj ponownie za około 5 minut.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Plik zip dla {file} nie mógł zostać utworzony.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Plik {file} nie mógł zostać przeniesiony do {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Proszę wybrać, jak strona powinna zostać oznaczona.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Strona została już oznaczona do synchronizacji</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Tabele MM takie jak {tableName} nie są już obsługiwane.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL zawiera uszkodzone wpisy. (Wpisy z uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>zakończono</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>To zadanie może potrwać, prosimy o cierpliwość.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Aktualności</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Użytkownicy i grupy backendu</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Grupy frontendu</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Zadania harmonogramu</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Przekierowania</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Stan tabeli</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Pojedyncze strony z treścią</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/pl.locallang_scheduler.xlf
+++ b/Resources/Private/Language/pl.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="pl" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Import synchronizacji</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Zadanie importu synchronizacji</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Ścieżka, w której przechowywane są pliki synchronizacji.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Ścieżka, w której przechowywane są pliki URL do wykonania.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/pt.locallang.xlf
+++ b/Resources/Private/Language/pt.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="pt" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Bloquear módulo de sincronização</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Mensagem para utilizadores em caso de bloqueio ativo</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/pt.locallang_mod.xlf
+++ b/Resources/Private/Language/pt.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="pt" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/pt.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/pt.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="pt" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Um módulo para sincronizar conteúdo de um sistema de produção para um ou vários sistemas de destino.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Criar nova sincronização</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Criar sincronização</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Forçar sincronização completa. Uma sincronização completa deste item é iniciada mesmo que uma sincronização incremental seja possível. Isto deve ser evitado, se possível.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Exclui registros obsoletos no sistema de destino. Quaisquer registros marcados como ocultos ou excluídos, ou onde o tempo de término do registro seja uma data no passado, serão excluídos no sistema de destino.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Status de sincronização da tabela</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabela</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Hora da última sincronização</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Tipo da última sincronização</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Utilizador da última sincronização</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>completa</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>incremental</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Lista de sincronização</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Sincronizações pendentes</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} ficheiro(s) aguardando sincronização {size}. Ficheiro mais antigo de {oldestFile} e, portanto, com {minutes} minutos.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Ficheiro</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Tamanho</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Item</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Ação</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Destino de sincronização:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Destino '{target}' desativado para sincronização.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Destino '{target}' ativado para sincronização.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Bloquear módulo de sincronização</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Desbloquear módulo de sincronização</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Bloquear destino de sincronização: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Desbloquear destino de sincronização: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Apenas página selecionada</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Página selecionada e todas as {pages} subpáginas</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(das quais {deleted} estão excluídas, {noaccess} estão bloqueadas e {falses} têm o tipo de página incorreto)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} subpáginas com {deleted} excluídas e {noaccess} inacessíveis)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Página: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Existem subáreas restritas que estão excluídas da sincronização.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Recursão</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Adicionar à lista de sincronização</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Definir profundidade de recursão</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Sinalizado destino '{target}' para nova sincronização.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>O destino '{target}' não pôde ser notificado devido a um erro.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Sinalização do destino '{target}' ignorada. Tipo de notificação desconhecido: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Sinalização do destino '{target}' ignorada devido à sinalização estar desativada.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Sinalização do destino '{target}' ignorada devido a contexto inválido. Contextos permitidos: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabela '{table}' ignorada - sem alterações desde a última sincronização.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sincronização de Assets iniciada</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sincronização iniciada.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sincronização iniciada - deve ser processada nos próximos 15 minutos.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Estado da tabela atualizado.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Criados {number} ficheiros de URL hook</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Nenhum dado extraído para processamento adicional. O processo de sincronização selecionado não produziu dados para serem sincronizados com o sistema de destino.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>O sistema '{target}' está bloqueado, portanto nenhum ficheiro de url é criado.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>As seguintes tabelas foram alteradas, por favor contacte o administrador TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>O sistema '{system} está bloqueado, portanto nenhum ficheiro de despejo é criado para ele.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Por favor, selecione uma página da árvore de páginas.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Não foi possível carregar o registo para a página selecionada: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>O tipo de página não deve ser sincronizado.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>O ficheiro de estado da tabela não é gravável.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Não há páginas marcadas para sincronização.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Já existe uma preparação de sincronização em andamento. Por favor, tente novamente em cerca de 5 minutos.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>O ficheiro zip para {file} não pôde ser criado.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>O ficheiro {file} não pôde ser movido para {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Por favor, selecione como a página deve ser marcada.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>A página já foi marcada para sincronização</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Tabelas MM como {tableName} já não são suportadas.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL tem entradas corrompidas. (Entradas com uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>concluído</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Esta tarefa pode demorar algum tempo, por favor seja paciente.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Notícias</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Utilizadores e grupos de backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Grupos de frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Tarefas do agendador</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirecionamentos</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Estado da tabela</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Páginas individuais com conteúdo</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/pt.locallang_scheduler.xlf
+++ b/Resources/Private/Language/pt.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="pt" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Importação de sincronização</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Tarefa para importar sincronizações</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Caminho onde os ficheiros de sincronização estão armazenados.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Caminho onde os ficheiros de URL a executar estão armazenados.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ro.locallang.xlf
+++ b/Resources/Private/Language/ro.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ro" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Blochează modulul de sincronizare</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Mesaj pentru utilizatori în cazul blocării active</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ro.locallang_mod.xlf
+++ b/Resources/Private/Language/ro.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ro" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/ro.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/ro.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ro" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Un modul pentru sincronizarea conținutului dintr-un sistem de producție către unul sau mai multe sisteme țintă.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Creează sincronizare nouă</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Creează sincronizare</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Forțează o sincronizare completă. O sincronizare completă a acestui element este inițiată chiar dacă este posibilă o sincronizare incrementală. Acest lucru ar trebui evitat, dacă este posibil.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Șterge înregistrările învechite din sistemul țintă. Orice înregistrări marcate ca ascunse sau șterse, sau unde timpul de sfârșit al înregistrării este o dată din trecut, vor fi șterse din sistemul țintă.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Starea sincronizării tabelului</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabel</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Ora ultimei sincronizări</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Tipul ultimei sincronizări</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Utilizatorul ultimei sincronizări</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>completă</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>incrementală</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Lista de sincronizare</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Sincronizări în așteptare</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} fișier(e) așteaptă sincronizarea {size}. Cel mai vechi fișier din {oldestFile} și prin urmare vechi de {minutes} minute.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Fișier</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Dimensiune</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Element</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Acțiune</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Țintă de sincronizare:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Ținta '{target}' dezactivată pentru sincronizare.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Ținta '{target}' activată pentru sincronizare.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Blochează modulul de sincronizare</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Deblochează modulul de sincronizare</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Blochează ținta de sincronizare: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Deblochează ținta de sincronizare: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Doar pagina selectată</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Pagina selectată și toate {pages} subpaginile</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(din care {deleted} sunt șterse, {noaccess} sunt blocate și {falses} au tipul de pagină greșit)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} subpagini cu {deleted} șterse și {noaccess} inaccesibile)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Pagină: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Există subzone restricționate care sunt excluse din sincronizare.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Recursivitate</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Adaugă în lista de sincronizare</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Setează adâncimea recursivității</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Semnalat ținta '{target}' pentru sincronizare nouă.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Ținta '{target}' nu a putut fi notificată din cauza unei erori.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Semnalarea țintei '{target}' omisă. Tip de notificare necunoscut: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Semnalarea țintei '{target}' omisă deoarece semnalizarea este dezactivată.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Semnalarea țintei '{target}' omisă din cauza contextului invalid. Contexte permise: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabelul '{table}' omis - fără modificări de la ultima sincronizare.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sincronizarea Assets inițiată</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sincronizare inițiată.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sincronizare începută - ar trebui să fie procesată în următoarele 15 minute.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Starea tabelului actualizată.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Creat {number} fișiere URL hook</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Nicio dată exportată pentru procesare ulterioară. Procesul de sincronizare selectat nu a produs date pentru a fi sincronizate cu sistemul țintă.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Sistemul '{target}' este blocat, astfel încât niciun fișier url nu este creat.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Următoarele tabele s-au modificat, vă rugăm contactați administratorul TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Sistemul '{system} este blocat, astfel încât niciun fișier de dump nu este creat pentru el.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Vă rugăm selectați o pagină din arborele de pagini.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Nu s-a putut încărca înregistrarea pentru pagina selectată: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Tipul de pagină nu trebuie sincronizat.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Fișierul de stare al tabelului nu este scris.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Nu există pagini marcate pentru sincronizare.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Este deja în curs o pregătire pentru sincronizare. Vă rugăm încercați din nou în aproximativ 5 minute.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Fișierul zip pentru {file} nu a putut fi creat.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Fișierul {file} nu a putut fi mutat în {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Vă rugăm selectați cum ar trebui marcată pagina.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Pagina a fost deja marcată pentru sincronizare</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Tabelele MM precum {tableName} nu mai sunt suportate.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL are intrări corupte. (Intrări cu uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>finalizat</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Această sarcină poate dura ceva timp, vă rugăm să fiți răbdător.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Știri</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Utilizatori și grupuri backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Grupuri frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Sarcini de programare</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirecționări</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Starea tabelului</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Pagini individuale cu conținut</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ro.locallang_scheduler.xlf
+++ b/Resources/Private/Language/ro.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ro" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Import sincronizare</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Sarcină pentru importul sincronizărilor</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Calea unde sunt stocate fișierele de sincronizare.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Calea unde sunt stocate fișierele URL de executat.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ru.locallang.xlf
+++ b/Resources/Private/Language/ru.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ru" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Заблокировать модуль синхронизации</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Сообщение для пользователей при активной блокировке</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ru.locallang_mod.xlf
+++ b/Resources/Private/Language/ru.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ru" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/ru.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/ru.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ru" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Модуль для синхронизации контента из производственной системы в одну или несколько целевых систем.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Создать новую синхронизацию</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Создать синхронизацию</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Принудительная полная синхронизация. Полная синхронизация элемента запускается, даже если возможна инкрементная синхронизация. По возможности этого следует избегать.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Удаляет устаревшие записи в целевой системе. Любые записи, помеченные как скрытые или удаленные, или у которых время окончания записи является прошедшей датой, будут удалены в целевой системе.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Статус синхронизации таблиц</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Таблица</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Время последней синхронизации</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Тип последней синхронизации</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Пользователь последней синхронизации</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>полная</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>инкрементная</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Список синхронизации</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Ожидающие синхронизации</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} файл(ов) ожидают синхронизации {size}. Самый старый файл от {oldestFile}, и поэтому возрастом {minutes} минут.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Файл</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Размер</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Элемент</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Действие</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Цель синхронизации:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Цель '{target}' отключена для синхронизации.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Цель '{target}' включена для синхронизации.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Заблокировать модуль синхронизации</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Разблокировать модуль синхронизации</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Заблокировать цель синхронизации: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Разблокировать цель синхронизации: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Только выбранная страница</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Выбранная страница и все {pages} подстраниц</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(из которых {deleted} удалены, {noaccess} заблокированы, и {falses} имеют неправильный тип страницы)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} подстраниц с {deleted} удаленными и {noaccess} недоступными)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Страница: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Существуют ограниченные подобласти, которые исключены из синхронизации.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Рекурсия</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Добавить в список синхронизации</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Установить глубину рекурсии</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Отправлен сигнал цели '{target}' для новой синхронизации.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Цель '{target}' не может быть уведомлена из-за ошибки.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Пропущена сигнализация цели '{target}'. Неизвестный тип уведомления: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Пропущена сигнализация цели '{target}' из-за отключенной сигнализации.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Пропущена сигнализация цели '{target}' из-за недействительного контекста. Разрешенные контексты: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Таблица '{table}' пропущена - нет изменений с последней синхронизации.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Синхронизация Assets инициирована</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Синхронизация инициирована.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Синхронизация запущена - должна быть обработана в течение следующих 15 минут.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Состояние таблицы обновлено.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Создано {number} файлов hook URL</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Нет данных, выгруженных для дальнейшей обработки. Выбранный процесс синхронизации не создал данных для синхронизации с целевой системой.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Система '{target}' заблокирована, поэтому url-файл не создан.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Следующие таблицы изменились, пожалуйста, свяжитесь с вашим администратором TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Система '{system} заблокирована, поэтому dump-файл для нее не создан.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Пожалуйста, выберите страницу из дерева страниц.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Невозможно загрузить запись для выбранной страницы: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Этот тип страницы не должен синхронизироваться.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Файл состояния таблицы недоступен для записи.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Нет страниц, отмеченных для синхронизации.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Уже выполняется подготовка к синхронизации. Пожалуйста, повторите попытку примерно через 5 минут.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zip-файл для {file} не может быть создан.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Файл {file} не может быть перемещен в {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Пожалуйста, выберите, как страница должна быть отмечена.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Страница уже отмечена для синхронизации</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM таблицы, такие как {tableName}, больше не поддерживаются.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL имеет поврежденные записи. (Записи с uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>выполнено</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Эта задача может занять некоторое время, пожалуйста, будьте терпеливы.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Новости</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (уровень абстракции файлов)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Пользователи и группы бэкенда</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Группы фронтенда</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Задачи планировщика</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Перенаправления</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Состояние таблицы</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Отдельные страницы с контентом</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/ru.locallang_scheduler.xlf
+++ b/Resources/Private/Language/ru.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="ru" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Импорт синхронизации</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Задача для импорта синхронизаций</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Путь, где хранятся файлы синхронизации.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Путь, где хранятся файлы URL для выполнения.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sr.locallang.xlf
+++ b/Resources/Private/Language/sr.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Закључај модул за синхронизацију</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Порука за кориснике у случају активног закључавања</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sr.locallang_mod.xlf
+++ b/Resources/Private/Language/sr.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/sr.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/sr.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Modul za sinhronizaciju sadržaja iz proizvodnog sistema u jedan ili više ciljnih sistema.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Napravi novu sinhronizaciju</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Napravi sinhronizaciju</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Prinudna potpuna sinhronizacija. Potpuna sinhronizacija stavke se pokreće čak i ako je moguća inkrementalna sinhronizacija. Ovo treba izbegavati ako je moguće.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Briše zastarele zapise na ciljnom sistemu. Svi zapisi koji su označeni kao sakriveni ili obrisani, ili gde je vreme završetka zapisa datum u prošlosti, biće obrisani na ciljnom sistemu.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Status sinhronizacije tabela</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabela</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Vreme poslednje sinhronizacije</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Tip poslednje sinhronizacije</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Korisnik poslednje sinhronizacije</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>potpuna</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>inkrementalna</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Lista sinhronizacije</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Sinhronizacije na čekanju</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} fajlova čeka sinhronizaciju {size}. Najstariji fajl od {oldestFile} i stoga star {minutes} minuta.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Fajl</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Veličina</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Stavka</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Akcija</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Cilj sinhronizacije:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Cilj '{target}' onemogućen za sinhronizaciju.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Cilj '{target}' omogućen za sinhronizaciju.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Zaključaj modul sinhronizacije</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Otključaj modul sinhronizacije</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Zaključaj cilj sinhronizacije: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Otključaj cilj sinhronizacije: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Samo izabrana stranica</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Izabrana stranica i svih {pages} podstranica</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(od kojih je {deleted} obrisano, {noaccess} blokirano, i {falses} ima pogrešan tip stranice)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} podstranica sa {deleted} obrisanih i {noaccess} nedostupnih)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Stranica: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Postoje ograničene podoblasti koje su isključene iz sinhronizacije.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekurzija</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Dodaj u listu sinhronizacije</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Postavi dubinu rekurzije</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Poslat signal cilju '{target}' za novu sinhronizaciju.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Cilj '{target}' nije mogao biti obavešten zbog greške.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Preskočeno signaliziranje cilja '{target}'. Nepoznat tip obaveštenja: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Preskočeno signaliziranje cilja '{target}' zbog onemogućenog signaliziranja.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Preskočeno signaliziranje cilja '{target}' zbog nevažećeg konteksta. Dozvoljeni konteksti: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabela '{table}' preskočena - nema promena od poslednje sinhronizacije.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Sinhronizacija Assets pokrenuta</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sinhronizacija pokrenuta.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sinhronizacija započeta - treba biti obrađena u narednih 15 minuta.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Stanje tabele ažurirano.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Kreirano {number} hook URL fajlova</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Nema izbačenih podataka za dalju obradu. Izabrani proces sinhronizacije nije proizveo podatke za sinhronizaciju sa ciljnim sistemom.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Sistem '{target}' je zaključan, tako da url fajl nije kreiran.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Sledeće tabele su promenjene, molimo kontaktirajte vašeg TYPO3 administratora:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Sistem '{system} je zaključan tako da dump fajl nije kreiran za njega.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Molimo izaberite stranicu iz stabla stranica.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Nije moguće učitati zapis za izabranu stranicu: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Tip stranice ne sme biti sinhronizovan.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Fajl stanja tabele nije dostupan za pisanje.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Nema stranica označenih za sinhronizaciju.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Već je u toku priprema za sinhronizaciju. Molimo pokušajte ponovo za oko 5 minuta.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zip fajl za {file} nije mogao biti kreiran.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Fajl {file} nije mogao biti premešten u {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Molimo izaberite kako stranica treba biti označena.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Stranica je već označena za sinhronizaciju</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM tabele kao što je {tableName} više nisu podržane.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL ima oštećene unose. (Unosi sa uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>gotovo</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Ovaj zadatak može potrajati, molimo budite strpljivi.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Vesti</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (sloj apstrakcije fajlova)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend korisnici i grupe</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend grupe</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Zadaci raspoređivača</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Preusmeravanja</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Stanje tabele</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Pojedinačne stranice sa sadržajem</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sr.locallang_scheduler.xlf
+++ b/Resources/Private/Language/sr.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Увоз синхронизације</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Задатак за увоз синхронизација</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Путања где су ускладиштене датотеке синхронизације.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Путања где су ускладиштене URL датотеке за извршавање.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sv.locallang.xlf
+++ b/Resources/Private/Language/sv.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sv" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Lås synkroniseringsmodul</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Meddelande till användare vid aktiv låsning</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sv.locallang_mod.xlf
+++ b/Resources/Private/Language/sv.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sv" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/sv.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/sv.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sv" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>En modul för att synkronisera innehåll från ett produktionssystem till ett eller flera målsystem.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Skapa ny synkronisering</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Skapa synkronisering</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Tvinga en fullständig synkronisering. En fullständig synkronisering av detta objekt initieras även om en inkrementell synkronisering är möjlig. Detta bör undvikas om möjligt.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Raderar föråldrade poster på målsystemet. Alla poster som är markerade som dolda eller raderade, eller där postens sluttid är ett datum i det förflutna, kommer att raderas på målsystemet.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Tabellsynkroniseringsstatus</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tabell</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Senaste synkroniseringstid</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Senaste synkroniseringstyp</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Senaste synkroniseringsanvändare</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>fullständig</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>inkrementell</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Synkroniseringslista</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Väntande synkroniseringar</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} fil(er) väntar på synkronisering {size}. Äldsta filen från {oldestFile} och därför {minutes} minuter gammal.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Fil</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Storlek</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Objekt</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Åtgärd</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Synkroniseringsmål:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Målet '{target}' inaktiverat för synkronisering.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Målet '{target}' aktiverat för synkronisering.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Lås synkroniseringsmodul</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Lås upp synkroniseringsmodul</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Lås synkroniseringsmål: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Lås upp synkroniseringsmål: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Endast vald sida</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Vald sida och alla {pages} undersidor</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(varav {deleted} är raderade, {noaccess} är blockerade, och {falses} har fel sidtyp)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} undersidor med {deleted} raderade och {noaccess} otillgängliga)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Sida: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Det finns begränsade delområden som är exkluderade från synkronisering.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Rekursion</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Lägg till i synkroniseringslista</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Ställ in rekursionsdjup</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Signalerade målet '{target}' för ny synkronisering.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Målet '{target}' kunde inte meddelas på grund av ett fel.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Hoppade över signalering av målet '{target}'. Okänd meddelandetyp: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Hoppade över signalering av målet '{target}' på grund av inaktiverad signalering.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Hoppade över signalering av målet '{target}' på grund av ogiltigt sammanhang. Tillåtna sammanhang: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Tabell '{table}' hoppades över - inga ändringar sedan senaste synkronisering.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Synkronisering av Assets initierad</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Synkronisering initierad.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Synkronisering startad - bör behandlas inom de närmaste 15 minuterna.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Uppdaterade tabelltillstånd.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Skapade {number} hook URL-filer</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Ingen data dumpades för vidare bearbetning. Den valda synkroniseringsprocessen producerade ingen data att synkronisera till målsystemet.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Systemet '{target}' är låst, så ingen url-fil skapas.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Följande tabeller har ändrats, vänligen kontakta din TYPO3-administratör:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Systemet '{system} är låst så ingen dumpfil skapas för det.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Vänligen välj en sida från sidträdet.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Kunde inte ladda post för vald sida: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Sidtypen får inte synkroniseras.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Tabelltillståndsfilen är inte skrivbar.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Det finns inga sidor markerade för synkronisering.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Det pågår redan en synkroniseringsförberedelse. Vänligen försök igen om cirka 5 minuter.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Zip-fil för {file} kunde inte skapas.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Filen {file} kunde inte flyttas till {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Vänligen välj hur sidan ska markeras.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Sidan har redan markerats för synkronisering</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM-tabeller som {tableName} stöds inte längre.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL har korrupta poster. (Poster med uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>klar</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Denna uppgift kan ta lite tid, vänligen ha tålamod.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Nyheter</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (filabstraktionslager)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend-användare och grupper</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend-grupper</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Schemaläggningsuppgifter</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Omdirigeringar</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Tabelltillstånd</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Enskilda sidor med innehåll</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sv.locallang_scheduler.xlf
+++ b/Resources/Private/Language/sv.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sv" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Synkroniseringsimport</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Uppgift för att importera synkroniseringar</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Sökväg där synkroniseringsfilerna lagras.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Sökväg där URL-filerna som ska köras lagras.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sw.locallang.xlf
+++ b/Resources/Private/Language/sw.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sw" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Funga moduli ya usawazishaji</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Ujumbe kwa watumiaji iwapo kufuli inafanya kazi</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sw.locallang_mod.xlf
+++ b/Resources/Private/Language/sw.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sw" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/sw.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/sw.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sw" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Moduli ya kusawazisha maudhui kutoka mfumo wa uzalishaji hadi mfumo mmoja au mifumo mingi lengwa.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Unda Sync mpya</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Unda Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Lazimisha usawazishaji kamili. Usawazishaji kamili wa kipengee hiki unaanzishwa hata kama usawazishaji wa nyongeza unawezekana. Hii inapaswa kuepukwa ikiwezekana.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Inafuta rekodi zilizopitwa na wakati kwenye mfumo lengwa. Rekodi zozote zilizoashiriwa kuwa zimefichwa au zimefutwa, au ambapo muda wa mwisho wa rekodi ni tarehe ya zamani, zitafutwa kwenye mfumo lengwa.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Hali ya usawazishaji wa jedwali</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Jedwali</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Muda wa usawazishaji wa mwisho</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Aina ya usawazishaji wa mwisho</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Mtumiaji wa usawazishaji wa mwisho</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>kamili</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>ya nyongeza</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Orodha ya Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Sync Zinazosubiri</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>Faili {files} zinasubiri usawazishaji {size}. Faili ya zamani zaidi kutoka {oldestFile} na kwa hiyo ina umri wa dakika {minutes}.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Faili</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Ukubwa</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Kipengee</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Kitendo</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Lengo la sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Lengo '{target}' limezimwa kwa sync.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Lengo '{target}' limewashwa kwa sync.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Funga moduli ya sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Fungua moduli ya sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Funga lengo la sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Fungua lengo la sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Ukurasa uliochaguliwa tu</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Ukurasa uliochaguliwa na kurasa za ndani {pages} zote</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(ambapo {deleted} zimefutwa, {noaccess} zimezuiwa, na {falses} zina aina ya ukurasa isiyo sahihi)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>(kurasa za ndani {pages} na {deleted} zimefutwa na {noaccess} hazipatikani)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Ukurasa: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Kuna maeneo madogo yaliyozuiliwa ambayo hayajumuishwi katika sync.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Urudishaji</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Ongeza kwenye orodha ya sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Weka kina cha urudishaji</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Lengo '{target}' limearifu kwa sync mpya.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Lengo '{target}' halikuweza kuarifishwa kwa sababu ya kosa.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Kuarifu lengo '{target}' kumerukwa. Aina ya arifa isiyojulikana: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Kuarifu lengo '{target}' kumerukwa kwa sababu arifa zimezimwa.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Kuarifu lengo '{target}' kumerukwa kwa sababu ya muktadha batili. Muktadha unaoruhusuliwa: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Jedwali '{table}' limerukwa - hakuna mabadiliko tangu usawazishaji wa mwisho.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Usawazishaji wa Assets umeanzishwa</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync imeanzishwa.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync imeanza - inapaswa kuchakatwa ndani ya dakika 15 zijazo.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Hali ya jedwali imesasishwa.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Faili {number} za URL za hook zimeundwa</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Hakuna data iliyotupwa kwa usindikaji zaidi. Mchakato wa sync uliochaguliwa haukuzalisha data yoyote ya kusawazishwa kwenye mfumo lengwa.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Mfumo '{target}' umefungwa, kwa hiyo hakuna faili ya url iliyoundwa.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Majedwali yafuatayo yamebadilika, tafadhali wasiliana na msimamizi wako wa TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Mfumo '{system} umefungwa kwa hiyo hakuna faili ya dump iliyoundwa kwa ajili yake.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Tafadhali chagua ukurasa kutoka kwenye mti wa kurasa.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Haikuweza kupakia rekodi kwa ukurasa uliochaguliwa: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Aina ya ukurasa haipaswi kusawazishwa.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Faili ya hali ya jedwali haiwezi kuandikwa.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Hakuna kurasa zilizowekwa alama kwa sync.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Tayari kuna maandalizi ya sync yanayoendelea. Tafadhali jaribu tena baada ya dakika 5.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Faili ya Zip kwa ajili ya {file} haikuweza kuundwa.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Faili {file} haikuweza kuhamishiwa {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Tafadhali chagua jinsi ukurasa unavyopaswa kuwekwa alama.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Ukurasa tayari umewekwa alama kwa usawazishaji</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Majedwali ya MM kama {tableName} hayatumiwi tena.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL ina maingizo yaliyoharibika. (Maingizo yenye uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>imekamilika</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Kazi hii inaweza kuchukua muda, tafadhali kuwa na uvumilivu.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Habari</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Watumiaji na vikundi vya backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Vikundi vya frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Kazi za ratiba</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirects</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Hali ya jedwali</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Kurasa za moja na maudhui</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/sw.locallang_scheduler.xlf
+++ b/Resources/Private/Language/sw.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="sw" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Ingiza usawazishaji</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Kazi ya kuingiza usawazishaji</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Njia ambapo faili za usawazishaji zimehifadhiwa.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Njia ambapo faili za URL za kutekelezwa zimehifadhiwa.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/th.locallang.xlf
+++ b/Resources/Private/Language/th.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="th" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>ล็อคโมดูลซิงค์</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>ข้อความสำหรับผู้ใช้ในกรณีที่มีการล็อคอยู่</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/th.locallang_mod.xlf
+++ b/Resources/Private/Language/th.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="th" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/th.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/th.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="th" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>โมดูลสำหรับการซิงโครไนซ์เนื้อหาจากระบบการผลิตไปยังระบบเป้าหมายเดียวหรือหลายระบบ</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>สร้าง Sync ใหม่</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>สร้าง Sync</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>บังคับให้ซิงค์แบบเต็ม การซิงค์แบบเต็มของรายการนี้จะเริ่มต้นแม้ว่าการซิงค์แบบเพิ่มหน่วยจะเป็นไปได้ ควรหลีกเลี่ยงหากเป็นไปได้</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>ลบเรคคอร์ดที่ล้าสมัยในระบบเป้าหมาย เรคคอร์ดใดๆ ที่ทำเครื่องหมายว่าซ่อนหรือถูกลบ หรือที่เวลาสิ้นสุดเรคคอร์ดเป็นวันที่ในอดีต จะถูกลบในระบบเป้าหมาย</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>สถานะการซิงค์ตาราง</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>ตาราง</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>เวลาซิงค์ครั้งล่าสุด</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>ประเภทการซิงค์ครั้งล่าสุด</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>ผู้ใช้ซิงค์ครั้งล่าสุด</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>เต็ม</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>เพิ่มหน่วย</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>รายการ Sync</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Sync ที่รอดำเนินการ</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>ไฟล์ {files} ไฟล์รอการซิงโครไนซ์ {size} ไฟล์เก่าที่สุดจาก {oldestFile} และมีอายุ {minutes} นาที</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>ไฟล์</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>ขนาด</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>รายการ</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>การดำเนินการ</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>เป้าหมาย sync:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>เป้าหมาย '{target}' ถูกปิดการใช้งานสำหรับ sync</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>เป้าหมาย '{target}' ถูกเปิดใช้งานสำหรับ sync</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>ล็อคโมดูล sync</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>ปลดล็อคโมดูล sync</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>ล็อคเป้าหมาย sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>ปลดล็อคเป้าหมาย sync: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>เฉพาะหน้าที่เลือก</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>หน้าที่เลือกและหน้าย่อยทั้งหมด {pages} หน้า</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(ซึ่ง {deleted} ถูกลบ {noaccess} ถูกบล็อก และ {falses} มีประเภทหน้าที่ไม่ถูกต้อง)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>(หน้าย่อย {pages} หน้าโดยมี {deleted} ถูกลบและ {noaccess} เข้าถึงไม่ได้)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>หน้า: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>มีพื้นที่ย่อยที่ถูกจำกัดซึ่งไม่รวมอยู่ใน sync</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>การเรียกซ้ำ</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>เพิ่มลงในรายการ sync</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>ตั้งค่าความลึกของการเรียกซ้ำ</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>ส่งสัญญาณเป้าหมาย '{target}' สำหรับ sync ใหม่</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>ไม่สามารถแจ้งเตือนเป้าหมาย '{target}' เนื่องจากข้อผิดพลาด</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>ข้ามการส่งสัญญาณเป้าหมาย '{target}' ประเภทการแจ้งเตือนที่ไม่รู้จัก: '{notify_type}'</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>ข้ามการส่งสัญญาณเป้าหมาย '{target}' เนื่องจากการส่งสัญญาณถูกปิดใช้งาน</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>ข้ามการส่งสัญญาณเป้าหมาย '{target}' เนื่องจากบริบทไม่ถูกต้อง บริบทที่อนุญาต: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>ข้ามตาราง '{table}' - ไม่มีการเปลี่ยนแปลงตั้งแต่การซิงค์ครั้งล่าสุด</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>เริ่มต้นการซิงค์ Assets</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>เริ่มต้น Sync แล้ว</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync เริ่มต้นแล้ว - ควรจะดำเนินการภายใน 15 นาทีถัดไป</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>อัพเดทสถานะตารางแล้ว</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>สร้างไฟล์ hook URL {number} ไฟล์</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>ไม่มีการถ่ายโอนข้อมูลสำหรับการประมวลผลต่อไป กระบวนการ sync ที่เลือกไม่ได้สร้างข้อมูลใดๆ ที่จะซิงค์ไปยังระบบเป้าหมาย</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>ระบบ '{target}' ถูกล็อค ดังนั้นจึงไม่มีการสร้างไฟล์ url</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>ตารางต่อไปนี้มีการเปลี่ยนแปลง กรุณาติดต่อผู้ดูแลระบบ TYPO3 ของคุณ:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>ระบบ '{system} ถูกล็อคดังนั้นจึงไม่มีการสร้างไฟล์ dump สำหรับระบบนี้</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>กรุณาเลือกหน้าจากแผนผังหน้า</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>ไม่สามารถโหลดเรคคอร์ดสำหรับหน้าที่เลือก: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>ประเภทหน้านี้ต้องไม่ถูกซิงโครไนซ์</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>ไฟล์สถานะตารางไม่สามารถเขียนได้</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>ไม่มีหน้าที่ทำเครื่องหมายเพื่อ sync</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>มีการเตรียม sync อยู่แล้ว กรุณาลองใหม่ในอีกประมาณ 5 นาที</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>ไม่สามารถสร้างไฟล์ Zip สำหรับ {file} ได้</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>ไม่สามารถย้ายไฟล์ {file} ไปยัง {target} ได้</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>กรุณาเลือกว่าจะทำเครื่องหมายหน้าอย่างไร</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>หน้านี้ได้ถูกทำเครื่องหมายสำหรับการซิงโครไนซ์แล้ว</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>ตาราง MM เช่น {tableName} ไม่รองรับอีกต่อไป</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL มีเรคคอร์ดที่เสียหาย (เรคคอร์ดที่มี uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>เสร็จสิ้น</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>งานนี้อาจใช้เวลาสักครู่ กรุณาอดทนรอ</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>ข่าว</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: ผู้ใช้และกลุ่มผู้ใช้ Backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: กลุ่ม Frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: งานตารางเวลา</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Redirects</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>สถานะตาราง</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: หน้าเดี่ยวพร้อมเนื้อหา</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/th.locallang_scheduler.xlf
+++ b/Resources/Private/Language/th.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="th" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>นำเข้าการซิงค์</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>งานสำหรับนำเข้าการซิงค์</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>พาธที่เก็บไฟล์ซิงค์</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>พาธที่เก็บไฟล์ URL ที่จะดำเนินการ</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/tr.locallang.xlf
+++ b/Resources/Private/Language/tr.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="tr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Senkronizasyon modülünü kilitle</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Aktif kilit durumunda kullanıcılar için mesaj</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/tr.locallang_mod.xlf
+++ b/Resources/Private/Language/tr.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="tr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/tr.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/tr.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="tr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Üretim sisteminden tek veya birden fazla hedef sisteme içerik senkronize etmek için bir modül.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Yeni Sync oluştur</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Sync Oluştur</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Tam senkronizasyonu zorla. Artımlı senkronizasyon mümkün olsa bile bu öğenin tam senkronizasyonu başlatılır. Mümkünse bundan kaçınılmalıdır.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Hedef sistemdeki eski kayıtları siler. Gizli veya silinmiş olarak işaretlenmiş veya kayıt bitiş zamanı geçmişte bir tarih olan tüm kayıtlar hedef sistemde silinecektir.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Tablo senkronizasyon durumu</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Tablo</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Son senkronizasyon zamanı</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Son senkronizasyon türü</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Son senkronizasyon kullanıcısı</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>tam</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>artımlı</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Sync Listesi</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Bekleyen Sync'ler</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} dosya senkronizasyon için bekliyor {size}. En eski dosya {oldestFile} tarihinden ve bu nedenle {minutes} dakikalık.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Dosya</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Boyut</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Öğe</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>İşlem</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Sync hedefi:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>'{target}' hedefi sync için devre dışı bırakıldı.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>'{target}' hedefi sync için etkinleştirildi.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Sync modülünü kilitle</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Sync modülünün kilidini aç</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Sync hedefini kilitle: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Sync hedefinin kilidini aç: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Yalnızca seçilen sayfa</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Seçilen sayfa ve tüm {pages} alt sayfa</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(bunlardan {deleted} silinmiş, {noaccess} engellenmiş ve {falses} yanlış sayfa türüne sahip)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} alt sayfa, {deleted} silinmiş ve {noaccess} erişilemez)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Sayfa: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Sync'den hariç tutulan kısıtlı alt alanlar bulunmaktadır.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Özyineleme</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Sync listesine ekle</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Özyineleme derinliğini ayarla</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Yeni sync için '{target}' hedefine sinyal gönderildi.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Bir hata nedeniyle '{target}' hedefine bildirim gönderilemedi.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>'{target}' hedefine sinyal gönderme atlandı. Bilinmeyen bildirim türü: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Sinyal gönderme devre dışı olduğu için '{target}' hedefine sinyal gönderme atlandı.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Geçersiz bağlam nedeniyle '{target}' hedefine sinyal gönderme atlandı. İzin verilen bağlamlar: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>'{table}' tablosu atlandı - son senkronizasyondan bu yana değişiklik yok.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Assets senkronizasyonu başlatıldı</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Sync başlatıldı.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Sync başladı - önümüzdeki 15 dakika içinde işlenmelidir.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Tablo durumu güncellendi.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>{number} hook URL dosyası oluşturuldu</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Daha fazla işlem için veri dökümü yapılmadı. Seçilen senkronizasyon işlemi hedef sisteme senkronize edilecek herhangi bir veri üretmedi.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>'{target}' sistemi kilitli, bu nedenle url dosyası oluşturulmadı.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Aşağıdaki tablolar değişti, lütfen TYPO3 yöneticinizle iletişime geçin:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>'{system} sistemi kilitli olduğu için bunun için dump dosyası oluşturulmadı.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Lütfen sayfa ağacından bir sayfa seçin.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Seçilen sayfa için kayıt yüklenemedi: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Sayfa türü senkronize edilmemelidir.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Tablo-durum-dosyası yazılabilir değil.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Senkronize edilmek üzere işaretlenmiş sayfa yok.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Zaten devam eden bir senkronizasyon hazırlığı var. Lütfen yaklaşık 5 dakika içinde tekrar deneyin.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>{file} için zip dosyası oluşturulamadı.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>{file} dosyası {target} konumuna taşınamadı.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Lütfen sayfanın nasıl işaretlenmesi gerektiğini seçin.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Sayfa zaten senkronizasyon için işaretlenmiş</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>{tableName} gibi MM tabloları artık desteklenmiyor.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL bozuk girişlere sahip. (uid_foreign = 0 olan girişler)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>tamamlandı</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Bu görevler biraz zaman alabilir, lütfen sabırlı olun.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Haberler</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Backend kullanıcıları ve grupları</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Frontend grupları</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Zamanlayıcı görevleri</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Yönlendirmeler</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Tablo durumu</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: İçerikli tekil sayfalar</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/tr.locallang_scheduler.xlf
+++ b/Resources/Private/Language/tr.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="tr" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Senkronizasyon içe aktarma</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Senkronizasyonları içe aktarma görevi</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Senkronizasyon dosyalarının depolandığı yol.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Çalıştırılacak URL dosyalarının depolandığı yol.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/uk.locallang.xlf
+++ b/Resources/Private/Language/uk.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="uk" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Заблокувати модуль синхронізації</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Повідомлення для користувачів у випадку активного блокування</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/uk.locallang_mod.xlf
+++ b/Resources/Private/Language/uk.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="uk" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/uk.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/uk.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="uk" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Модуль для синхронізації контенту з виробничої системи в одну або кілька цільових систем.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Створити нову синхронізацію</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Створити синхронізацію</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Примусова повна синхронізація. Повна синхронізація цього елемента ініціюється, навіть якщо можлива інкрементальна синхронізація. По можливості слід уникати.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Видаляє застарілі записи в цільовій системі. Будь-які записи, які позначені як приховані або видалені, або час завершення яких є датою в минулому, будуть видалені в цільовій системі.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Статус синхронізації таблиці</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Таблиця</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Час останньої синхронізації</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Тип останньої синхронізації</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Користувач останньої синхронізації</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>повна</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>інкрементальна</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Список синхронізації</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Очікувані синхронізації</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} файл(ів) очікують синхронізації {size}. Найстаріший файл від {oldestFile} і тому {minutes} хвилин.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Файл</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Розмір</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Елемент</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Дія</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Ціль синхронізації:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Ціль '{target}' відключена для синхронізації.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Ціль '{target}' увімкнена для синхронізації.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Заблокувати модуль синхронізації</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Розблокувати модуль синхронізації</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Заблокувати ціль синхронізації: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Розблокувати ціль синхронізації: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Тільки обрана сторінка</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Обрана сторінка і всі {pages} підсторінки</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(з яких {deleted} видалені, {noaccess} заблоковані, і {falses} мають неправильний тип сторінки)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} підсторінок з {deleted} видаленими і {noaccess} недоступними)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Сторінка: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Існують обмежені підрозділи, які виключені із синхронізації.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Рекурсія</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Додати до списку синхронізації</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Встановити глибину рекурсії</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Сигнал надіслано цілі '{target}' для нової синхронізації.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Ціль '{target}' не вдалося сповістити через помилку.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Пропущено сигнал цілі '{target}'. Невідомий тип сповіщення: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Пропущено сигнал цілі '{target}' через відключене сповіщення.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Пропущено сигнал цілі '{target}' через недійсний контекст. Дозволені контексти: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Таблицю '{table}' пропущено - немає змін з останньої синхронізації.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Синхронізація Assets ініційована</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Синхронізацію ініційовано.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Синхронізацію розпочато - має бути оброблена протягом наступних 15 хвилин.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Стан таблиці оновлено.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Створено {number} файлів hook URL</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Дані не вивантажено для подальшої обробки. Обраний процес синхронізації не створив жодних даних для синхронізації з цільовою системою.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Система '{target}' заблокована, тому файл URL не створено.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Наступні таблиці змінилися, будь ласка, зверніться до адміністратора TYPO3:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Система '{system} заблокована, тому для неї не створюється dump-файл.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Будь ласка, виберіть сторінку з дерева сторінок.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Не вдалося завантажити запис для обраної сторінки: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Цей тип сторінки не підлягає синхронізації.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Файл стану таблиці недоступний для запису.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Немає сторінок, позначених для синхронізації.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Вже виконується підготовка до синхронізації. Будь ласка, повторіть спробу приблизно через 5 хвилин.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Не вдалося створити Zip-файл для {file}.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Не вдалося перемістити файл {file} до {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Будь ласка, виберіть, як має бути позначена сторінка.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Сторінка вже позначена для синхронізації</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>MM таблиці, такі як {tableName}, більше не підтримуються.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL має пошкоджені записи. (Записи з uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>виконано</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Ці завдання можуть зайняти деякий час, будь ласка, будьте терплячими.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Новини</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Користувачі та групи бекенду</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Групи фронтенду</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Завдання планувальника</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Перенаправлення</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Стан таблиці</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Окремі сторінки з вмістом</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/uk.locallang_scheduler.xlf
+++ b/Resources/Private/Language/uk.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="uk" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Імпорт синхронізації</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Завдання для імпорту синхронізацій</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Шлях, де зберігаються файли синхронізації.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Шлях, де зберігаються файли URL для виконання.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/vi.locallang.xlf
+++ b/Resources/Private/Language/vi.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="vi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>Khóa mô-đun đồng bộ hóa</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>Thông báo cho người dùng trong trường hợp khóa đang hoạt động</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/vi.locallang_mod.xlf
+++ b/Resources/Private/Language/vi.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="vi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/vi.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/vi.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="vi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>Mô-đun để đồng bộ hóa nội dung từ hệ thống sản xuất sang một hoặc nhiều hệ thống đích.</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>Tạo đồng bộ mới</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>Tạo đồng bộ</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>Buộc đồng bộ hoàn toàn. Đồng bộ hoàn toàn mục này được bắt đầu ngay cả khi có thể đồng bộ tăng dần. Nên tránh điều này nếu có thể.</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>Xóa các bản ghi lỗi thời trên hệ thống đích. Bất kỳ bản ghi nào được đánh dấu là ẩn hoặc đã xóa, hoặc thời gian kết thúc bản ghi là ngày trong quá khứ, sẽ bị xóa trên hệ thống đích.</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>Trạng thái đồng bộ bảng</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>Bảng</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>Thời gian đồng bộ cuối</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>Loại đồng bộ cuối</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>Người dùng đồng bộ cuối</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>hoàn toàn</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>tăng dần</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>Danh sách đồng bộ</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>Đồng bộ đang chờ</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} tệp đang chờ đồng bộ hóa {size}. Tệp cũ nhất từ {oldestFile} và do đó {minutes} phút tuổi.</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>Tệp</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>Kích thước</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>Mục</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>Hành động</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>Đích đồng bộ:</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>Đích '{target}' đã bị vô hiệu hóa cho đồng bộ.</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>Đích '{target}' đã được kích hoạt cho đồng bộ.</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>Khóa mô-đun đồng bộ</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>Mở khóa mô-đun đồng bộ</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>Khóa đích đồng bộ: {system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>Mở khóa đích đồng bộ: {system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>Chỉ trang đã chọn</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>Trang đã chọn và tất cả {pages} trang con</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>(trong đó {deleted} bị xóa, {noaccess} bị chặn, và {falses} có loại trang sai)</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>({pages} trang con với {deleted} bị xóa và {noaccess} không thể truy cập)</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>Trang: {id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>Có các khu vực con bị hạn chế được loại trừ khỏi đồng bộ.</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>Đệ quy</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>Thêm vào danh sách đồng bộ</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>Đặt độ sâu đệ quy</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>Đã báo hiệu đích '{target}' cho đồng bộ mới.</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>Không thể thông báo cho đích '{target}' do lỗi.</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>Đã bỏ qua báo hiệu đích '{target}'. Loại thông báo không xác định: '{notify_type}'.</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>Đã bỏ qua báo hiệu đích '{target}' do báo hiệu bị vô hiệu hóa.</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>Đã bỏ qua báo hiệu đích '{target}' do ngữ cảnh không hợp lệ. Ngữ cảnh được phép: {allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>Đã bỏ qua bảng '{table}' - không có thay đổi kể từ lần đồng bộ cuối.</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>Đã khởi tạo đồng bộ Assets</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>Đã khởi tạo đồng bộ.</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>Đã bắt đầu đồng bộ - sẽ được xử lý trong vòng 15 phút tiếp theo.</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>Đã cập nhật trạng thái bảng.</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>Đã tạo {number} tệp hook URL</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>Không có dữ liệu được xuất cho xử lý tiếp theo. Quá trình đồng bộ đã chọn không tạo ra dữ liệu nào để đồng bộ với hệ thống đích.</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>Hệ thống '{target}' bị khóa, vì vậy không có tệp URL được tạo.</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>Các bảng sau đã thay đổi, vui lòng liên hệ quản trị viên TYPO3 của bạn:</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>Hệ thống '{system} bị khóa nên không có tệp dump được tạo cho nó.</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>Vui lòng chọn một trang từ cây trang.</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>Không thể tải bản ghi cho trang đã chọn: {page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>Loại trang này không được phép đồng bộ.</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>Tệp trạng thái bảng không thể ghi.</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>Không có trang nào được đánh dấu để đồng bộ.</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>Đã có một quá trình chuẩn bị đồng bộ đang diễn ra. Vui lòng thử lại sau khoảng 5 phút.</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>Không thể tạo tệp Zip cho {file}.</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>Không thể di chuyển tệp {file} đến {target}.</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>Vui lòng chọn cách trang nên được đánh dấu.</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>Trang đã được đánh dấu để đồng bộ</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>Các bảng MM như {tableName} không còn được hỗ trợ nữa.</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL có các mục bị hỏng. (Các mục với uid_foreign = 0)</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>hoàn thành</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>Các tác vụ này có thể mất một chút thời gian, vui lòng kiên nhẫn.</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>Tin tức</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: Người dùng và nhóm backend</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: Nhóm frontend</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: Tác vụ lập lịch</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: Chuyển hướng</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>Trạng thái bảng</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: Trang đơn có nội dung</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/vi.locallang_scheduler.xlf
+++ b/Resources/Private/Language/vi.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="vi" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>Nhập đồng bộ hóa</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>Tác vụ để nhập đồng bộ hóa</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>Đường dẫn nơi lưu trữ các tệp đồng bộ hóa.</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>Đường dẫn nơi lưu trữ các tệp URL để thực thi.</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/zh.locallang.xlf
+++ b/Resources/Private/Language/zh.locallang.xlf
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="zh" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="lock.label">
         <source>Lock sync module</source>
-        <target>Synchronisierungsmodul sperren</target>
+        <target>锁定同步模块</target>
       </trans-unit>
       <trans-unit id="lock.message">
         <source>Message for users in case of active lock</source>
-        <target>Meldung an Benutzer bei aktiver Sperre</target>
+        <target>锁定激活时给用户的消息</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/zh.locallang_mod.xlf
+++ b/Resources/Private/Language/zh.locallang_mod.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" target-language="de" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="zh" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Netresearch</source>

--- a/Resources/Private/Language/zh.locallang_mod_sync.xlf
+++ b/Resources/Private/Language/zh.locallang_mod_sync.xlf
@@ -1,231 +1,306 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="zh" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="mlang_tabs_tab">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tablabel">
         <source>Sync</source>
+        <target>Sync</target>
       </trans-unit>
       <trans-unit id="mlang_labels_tabdescr">
         <source>A module for synchronizing content from a production system to a single or multiple target systems.</source>
+        <target>用于将内容从生产系统同步到单个或多个目标系统的模块。</target>
       </trans-unit>
       <trans-unit id="headline.create_sync">
         <source>Create new Sync</source>
+        <target>创建新同步</target>
       </trans-unit>
       <trans-unit id="button.create_sync">
         <source>Create Sync</source>
+        <target>创建同步</target>
       </trans-unit>
       <trans-unit id="label.force_full_sync">
         <source>Force a full sync. A full sync of this item is initiated even if an incremental sync is possible. This should be avoided if possible.</source>
+        <target>强制完全同步。即使可以进行增量同步，也会启动此项目的完全同步。应尽可能避免。</target>
       </trans-unit>
       <trans-unit id="label.delete_obsolete_rows">
         <source>Deletes obsolete records on the target system. Any records that are marked as hidden or deleted, or where the record end time is a date in the past, will be deleted on the target system.</source>
+        <target>删除目标系统上的过时记录。任何标记为隐藏或已删除，或记录结束时间为过去日期的记录，都将在目标系统上删除。</target>
       </trans-unit>
       <trans-unit id="headline.table_state">
         <source>Table sync status</source>
+        <target>表同步状态</target>
       </trans-unit>
       <trans-unit id="column.table">
         <source>Table</source>
+        <target>表</target>
       </trans-unit>
       <trans-unit id="column.last_sync">
         <source>Last sync time</source>
+        <target>最后同步时间</target>
       </trans-unit>
       <trans-unit id="column.last_type">
         <source>Last sync type</source>
+        <target>最后同步类型</target>
       </trans-unit>
       <trans-unit id="column.last_user">
         <source>Last sync user</source>
+        <target>最后同步用户</target>
       </trans-unit>
       <trans-unit id="sync_type.full">
         <source>full</source>
+        <target>完全</target>
       </trans-unit>
       <trans-unit id="sync_type.incr">
         <source>incremental</source>
+        <target>增量</target>
       </trans-unit>
       <trans-unit id="headline.sync_list">
         <source>Sync List</source>
+        <target>同步列表</target>
       </trans-unit>
       <trans-unit id="headline.waiting_syncs">
         <source>Waiting Syncs</source>
+        <target>等待中的同步</target>
       </trans-unit>
       <trans-unit id="waitingfiles">
         <source>{files} file(s) waiting for synchronisation {size}. Oldest file from {oldestFile} and therefore {minutes} minutes old.</source>
+        <target>{files} 个文件等待同步 {size}。最旧文件来自 {oldestFile}，因此已有 {minutes} 分钟。</target>
       </trans-unit>
       <trans-unit id="column.file">
         <source>File</source>
+        <target>文件</target>
       </trans-unit>
       <trans-unit id="column.size">
         <source>Size</source>
+        <target>大小</target>
       </trans-unit>
       <trans-unit id="column.item">
         <source>Item</source>
+        <target>项目</target>
       </trans-unit>
       <trans-unit id="column.action">
         <source>Action</source>
+        <target>操作</target>
       </trans-unit>
       <trans-unit id="label.sync_target">
         <source>Sync target:</source>
+        <target>同步目标：</target>
       </trans-unit>
       <trans-unit id="message.target_locked">
         <source>Target '{target}' disabled for sync.</source>
+        <target>目标 '{target}' 已禁用同步。</target>
       </trans-unit>
       <trans-unit id="message.target_unlocked">
         <source>Target '{target}' enabled for sync.</source>
+        <target>目标 '{target}' 已启用同步。</target>
       </trans-unit>
       <trans-unit id="label.lock_module">
         <source>Lock sync module</source>
+        <target>锁定同步模块</target>
       </trans-unit>
       <trans-unit id="label.unlock_module">
         <source>Unlock sync module</source>
+        <target>解锁同步模块</target>
       </trans-unit>
       <trans-unit id="label.lock_target">
         <source>Lock sync target: {system}</source>
+        <target>锁定同步目标：{system}</target>
       </trans-unit>
       <trans-unit id="label.unlock_target">
         <source>Unlock sync target: {system}</source>
+        <target>解锁同步目标：{system}</target>
       </trans-unit>
       <trans-unit id="label.page_only">
         <source>Only selected page</source>
+        <target>仅选定页面</target>
       </trans-unit>
       <trans-unit id="label.page_and_subpages">
         <source>Selected page and all {pages} sub pages</source>
+        <target>选定页面和所有 {pages} 个子页面</target>
       </trans-unit>
       <trans-unit id="label.subpages_including">
         <source>(of which {deleted} are deleted, {noaccess} are blocked, and {falses} have the wrong page type)</source>
+        <target>（其中 {deleted} 已删除，{noaccess} 被阻止，{falses} 页面类型错误）</target>
       </trans-unit>
       <trans-unit id="label.list_with_subs">
         <source>({pages} subpages with {deleted} deleted and {noaccess} inaccessible)</source>
+        <target>（{pages} 个子页面，其中 {deleted} 已删除，{noaccess} 不可访问）</target>
       </trans-unit>
       <trans-unit id="label.page">
         <source>Page: {id}</source>
+        <target>页面：{id}</target>
       </trans-unit>
       <trans-unit id="label.excluded_pages">
         <source>There are restricted subareas which are excluded from sync.</source>
+        <target>存在被排除在同步之外的受限子区域。</target>
       </trans-unit>
       <trans-unit id="label.recursion">
         <source>Recursion</source>
+        <target>递归</target>
       </trans-unit>
       <trans-unit id="button.add_to_list">
         <source>Add to sync list</source>
+        <target>添加到同步列表</target>
       </trans-unit>
       <trans-unit id="button.recursion_depth">
         <source>Set recursion depth</source>
+        <target>设置递归深度</target>
       </trans-unit>
       <trans-unit id="message.notify_success">
         <source>Signaled '{target}' target for new sync.</source>
+        <target>已向目标 '{target}' 发送新同步信号。</target>
       </trans-unit>
       <trans-unit id="message.notify_failed">
         <source>Target '{target}' could not be notified due to an error.</source>
+        <target>由于错误，无法通知目标 '{target}'。</target>
       </trans-unit>
       <trans-unit id="message.notify_unknown">
         <source>Skipped signaling '{target}' target. Unknown notify type: '{notify_type}'.</source>
+        <target>已跳过向目标 '{target}' 发送信号。未知通知类型：'{notify_type}'。</target>
       </trans-unit>
       <trans-unit id="message.notify_disabled">
         <source>Skipped signaling '{target}' target due to signaling disabled.</source>
+        <target>由于信号已禁用，已跳过向目标 '{target}' 发送信号。</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_context">
         <source>Skipped signaling '{target}' target due to invalid context. Allowed contexts: {allowed_contexts}</source>
+        <target>由于上下文无效，已跳过向目标 '{target}' 发送信号。允许的上下文：{allowed_contexts}</target>
       </trans-unit>
       <trans-unit id="message.notify_skipped_table">
         <source>Table '{table}' skipped - no changes since last sync.</source>
+        <target>已跳过表 '{table}' - 自上次同步以来没有更改。</target>
       </trans-unit>
       <trans-unit id="success.sync_assest_init">
         <source>Sync assets initiated</source>
+        <target>已启动 Assets 同步</target>
       </trans-unit>
       <trans-unit id="success.sync_initiated">
         <source>Sync initiated.</source>
+        <target>已启动同步。</target>
       </trans-unit>
       <trans-unit id="success.sync_in_progress">
         <source>Sync started - should be processed within in next 15 minutes.</source>
+        <target>同步已开始 - 应在接下来的 15 分钟内处理。</target>
       </trans-unit>
       <trans-unit id="message.table_state_success">
         <source>Updated table state.</source>
+        <target>已更新表状态。</target>
       </trans-unit>
       <trans-unit id="message.hook_files">
         <source>Created {number} hook URL files</source>
+        <target>已创建 {number} 个钩子 URL 文件</target>
       </trans-unit>
       <trans-unit id="info.no_data_dumped">
         <source>No data dumped for further processing. The selected sync process did not produce any data to be synced to the target system.</source>
+        <target>没有导出数据供进一步处理。所选同步过程未产生任何要同步到目标系统的数据。</target>
       </trans-unit>
       <trans-unit id="warning.urls_system_locked">
         <source>System '{target}' is locked, so no url file is created.</source>
+        <target>系统 '{target}' 已锁定，因此不会创建 URL 文件。</target>
       </trans-unit>
       <trans-unit id="warning.table_state">
         <source>Following tables have changed, please contact your TYPO3 admin:</source>
+        <target>以下表已更改，请联系您的 TYPO3 管理员：</target>
       </trans-unit>
       <trans-unit id="warning.system_locked">
         <source>System '{system} is locked so no dump-file is created for it.</source>
+        <target>系统 '{system} 已锁定，因此不会为其创建转储文件。</target>
       </trans-unit>
       <trans-unit id="error.no_page">
         <source>Please select a page from the page tree.</source>
+        <target>请从页面树中选择一个页面。</target>
       </trans-unit>
       <trans-unit id="error.page_not_load">
         <source>Could not load record for selected page: {page_selected}</source>
+        <target>无法加载所选页面的记录：{page_selected}</target>
       </trans-unit>
       <trans-unit id="error.page_type_not_allowed">
         <source>The page type must not be synchronized.</source>
+        <target>此页面类型不得同步。</target>
       </trans-unit>
       <trans-unit id="error.could_not_write_tablestate">
         <source>Table-state-file is not writable.</source>
+        <target>表状态文件不可写。</target>
       </trans-unit>
       <trans-unit id="error.no_pages_marked">
         <source>There are no pages marked to sync.</source>
+        <target>没有标记要同步的页面。</target>
       </trans-unit>
       <trans-unit id="error.last_sync_not_finished">
         <source>There ist already a sync-preparation in progress. Please retry in about 5 minutes.</source>
+        <target>已有同步准备正在进行中。请在约 5 分钟后重试。</target>
       </trans-unit>
       <trans-unit id="error.zip_failure">
         <source>Zipfile for {file} could not be created.</source>
+        <target>无法为 {file} 创建 Zip 文件。</target>
       </trans-unit>
       <trans-unit id="error.cannot_move_file">
         <source>File {file} could not be moved to {target}.</source>
+        <target>无法将文件 {file} 移动到 {target}。</target>
       </trans-unit>
       <trans-unit id="error.select_mark_type">
         <source>Please select how the page should be marked.</source>
+        <target>请选择如何标记页面。</target>
       </trans-unit>
       <trans-unit id="error.page_is_marked">
         <source>The page has been already marked for synchronisation</source>
+        <target>该页面已被标记为同步</target>
       </trans-unit>
       <trans-unit id="error.mm_tables">
         <source>MM tables like {tableName} are not supported anymore.</source>
+        <target>不再支持像 {tableName} 这样的 MM 表。</target>
       </trans-unit>
       <trans-unit id="error.fal_dirty">
         <source>FAL has corrupted entries. (Entries with uid_foreign = 0)</source>
+        <target>FAL 具有损坏的条目。（uid_foreign = 0 的条目）</target>
       </trans-unit>
       <trans-unit id="label.done">
         <source>done</source>
+        <target>完成</target>
       </trans-unit>
       <trans-unit id="label.clean_fal">
         <source>This tasks can take some time, please be patient.</source>
+        <target>这些任务可能需要一些时间，请耐心等待。</target>
       </trans-unit>
       <trans-unit id="mod_news">
         <source>News</source>
+        <target>新闻</target>
       </trans-unit>
       <trans-unit id="mod_fal">
         <source>TYPO3: FAL (File Abstraction Layer)</source>
+        <target>TYPO3: FAL (File Abstraction Layer)</target>
       </trans-unit>
       <trans-unit id="mod_asset">
         <source>Assets</source>
+        <target>Assets</target>
       </trans-unit>
       <trans-unit id="mod_be_users">
         <source>TYPO3: Backend users and groups</source>
+        <target>TYPO3: 后端用户和组</target>
       </trans-unit>
       <trans-unit id="mod_fe_groups">
         <source>TYPO3: Frontend groups</source>
+        <target>TYPO3: 前端组</target>
       </trans-unit>
       <trans-unit id="mod_scheduler">
         <source>TYPO3: Scheduler tasks</source>
+        <target>TYPO3: 调度任务</target>
       </trans-unit>
       <trans-unit id="mod_redirect">
         <source>TYPO3: Redirects</source>
+        <target>TYPO3: 重定向</target>
       </trans-unit>
       <trans-unit id="mod_tableState">
         <source>Table state</source>
+        <target>表状态</target>
       </trans-unit>
       <trans-unit id="mod_singlePage">
         <source>TYPO3: Single pages with content</source>
+        <target>TYPO3: 带有内容的单个页面</target>
       </trans-unit>
     </body>
   </file>

--- a/Resources/Private/Language/zh.locallang_scheduler.xlf
+++ b/Resources/Private/Language/zh.locallang_scheduler.xlf
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_sync">
+  <file source-language="en" target-language="zh" datatype="plaintext" original="messages" product-name="nr_sync">
     <body>
       <trans-unit id="tx_nrcsync_scheduler_import.name">
         <source>Import Sync</source>
+        <target>导入同步</target>
       </trans-unit>
       <trans-unit id="tx_nrcsync_scheduler_import.description">
         <source>Task to import syncs</source>
+        <target>导入同步的任务</target>
       </trans-unit>
       <trans-unit id="syncStoragePath">
         <source>Path where the sync files are stored in.</source>
+        <target>同步文件存储路径。</target>
       </trans-unit>
       <trans-unit id="syncUrlsPath">
         <source>Path where the urls files to execute are stored in.</source>
+        <target>待执行URL文件存储路径。</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Summary
- Convert all existing XLIFF files to XLIFF 1.2 format with proper namespace
- Add source elements to German translation files (required for XLIFF 1.2)
- Fix bug in `de.locallang_mod_sync.xlf` where `error.mm_tables` had `<source>` instead of `<target>`
- Apply consistent 2-space indentation per .editorconfig
- Add translations for 30 languages: af, ar, ca, cs, da, el, es, fi, fr, he, hi, hu, id, it, ja, ko, nl, no, pl, pt, ro, ru, sr, sv, sw, th, tr, uk, vi, zh

## Changes
- 8 modified files (existing en/de translations converted to XLIFF 1.2)
- 120 new files (30 languages × 4 XLIFF files)

## Test plan
- [x] All 128 XLIFF files pass XML validation
- [x] All files have proper XLIFF 1.2 namespace and version
- [x] All files use consistent 2-space indentation
- [x] Translations verified for multiple languages including RTL (Arabic, Hebrew)