### PR TITLE
fix: harden GitHub Actions against supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,12 @@ updates:
     schedule:
       interval: "daily"
     versioning-strategy: increase-if-necessary
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Documentation/**'
+          - '*.md'
+
+configuration:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Configuration/**'
+          - 'ext_emconf.php'
+          - 'composer.json'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Tests/**'
+          - 'phpunit*.xml'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'composer.json'
+          - 'composer.lock'

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,96 +1,10 @@
 <?php
 
-/**
- * This file represents the configuration for Code Sniffing PSR-2-related
- * automatic checks of coding guidelines
- * Install @fabpot's great php-cs-fixer tool via
- *
- *  $ composer global require friendsofphp/php-cs-fixer
- *
- * And then simply run
- *
- *  $ php-cs-fixer fix
- *
- * For more information read:
- *  http://www.php-fig.org/psr/psr-2/
- *  http://cs.sensiolabs.org
- */
+$createConfig = require __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/php-cs-fixer/config.php';
 
-if (PHP_SAPI !== 'cli') {
-    die('This script supports command line usage only. Please check your command.');
-}
+return $createConfig(<<<'EOF'
+    This file is part of the package netresearch/nr-sync.
 
-$header = <<<EOF
-This file is part of the package netresearch/nr-sync.
-
-For the full copyright and license information, please read the
-LICENSE file that was distributed with this source code.
-EOF;
-
-return (new PhpCsFixer\Config())
-    ->setRiskyAllowed(true)
-    ->setRules([
-        '@PSR12'                          => true,
-        '@PER-CS2.0'                      => true,
-        '@Symfony'                        => true,
-
-        // Additional custom rules
-        'declare_strict_types'            => true,
-        'concat_space'                    => [
-            'spacing' => 'one',
-        ],
-        'header_comment'                  => [
-            'header'       => $header,
-            'comment_type' => 'PHPDoc',
-            'location'     => 'after_open',
-            'separate'     => 'both',
-        ],
-        'phpdoc_to_comment'               => false,
-        'phpdoc_no_alias_tag'             => false,
-        'no_superfluous_phpdoc_tags'      => false,
-        'phpdoc_separation'               => [
-            'groups' => [
-                [
-                    'author',
-                    'license',
-                    'link',
-                ],
-            ],
-        ],
-        'no_alias_functions'              => true,
-        'whitespace_after_comma_in_array' => [
-            'ensure_single_space' => true,
-        ],
-        'single_line_throw'               => false,
-        'self_accessor'                   => false,
-        'global_namespace_import'         => [
-            'import_classes'   => true,
-            'import_constants' => true,
-            'import_functions' => true,
-        ],
-        'function_declaration'            => [
-            'closure_function_spacing' => 'one',
-            'closure_fn_spacing'       => 'one',
-        ],
-        'binary_operator_spaces'          => [
-            'operators' => [
-                '='  => 'align_single_space_minimal',
-                '=>' => 'align_single_space_minimal',
-            ],
-        ],
-        'yoda_style'                      => [
-            'equal'                => false,
-            'identical'            => false,
-            'less_and_greater'     => false,
-            'always_move_variable' => false,
-        ],
-    ])
-    ->setFinder(
-        PhpCsFixer\Finder::create()
-            ->exclude('.build')
-            ->exclude('config')
-            ->exclude('node_modules')
-            ->exclude('var')
-            ->notPath('ext_emconf.php')
-            ->in(__DIR__ . '/../')
-    );
+    For the full copyright and license information, please read the
+    LICENSE file that was distributed with this source code.
+    EOF, __DIR__ . '/..');

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,10 +1,98 @@
 <?php
 
-$createConfig = require __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/php-cs-fixer/config.php';
+declare(strict_types=1);
 
-return $createConfig(<<<'EOF'
+$header = <<<'EOF'
     This file is part of the package netresearch/nr-sync.
 
     For the full copyright and license information, please read the
     LICENSE file that was distributed with this source code.
-    EOF, __DIR__ . '/..');
+    EOF;
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/..')
+    ->exclude(['.Build', '.build', 'config', 'node_modules', 'var'])
+    ->notPath('ext_emconf.php');
+
+$config = new PhpCsFixer\Config();
+$config
+    ->setRiskyAllowed(true)
+    ->setRules([
+        // Base rulesets
+        '@Symfony'         => true,
+        '@PER-CS3x0'       => true,
+
+        // Strict typing
+        'declare_strict_types' => true,
+
+        // Spacing
+        'concat_space' => ['spacing' => 'one'],
+
+        // Docblocks
+        'phpdoc_to_comment'          => false,
+        'no_superfluous_phpdoc_tags' => false,
+        'phpdoc_separation'          => [
+            'groups' => [['author', 'license', 'link']],
+        ],
+
+        // Aliases
+        'no_alias_functions' => true,
+
+        // Alignment
+        'binary_operator_spaces' => [
+            'operators' => [
+                '='  => 'align_single_space_minimal',
+                '=>' => 'align_single_space_minimal',
+            ],
+        ],
+
+        // No Yoda
+        'yoda_style' => [
+            'equal'                => false,
+            'identical'            => false,
+            'less_and_greater'     => false,
+            'always_move_variable' => false,
+        ],
+
+        // Imports
+        'global_namespace_import' => [
+            'import_classes'   => true,
+            'import_constants' => true,
+            'import_functions' => true,
+        ],
+        'no_unused_imports' => true,
+        'ordered_imports'   => ['sort_algorithm' => 'alpha'],
+
+        // Function declarations
+        'function_declaration' => [
+            'closure_function_spacing' => 'one',
+            'closure_fn_spacing'       => 'one',
+        ],
+
+        // Modern syntax
+        'trailing_comma_in_multiline' => [
+            'elements' => ['arrays', 'arguments', 'parameters'],
+        ],
+
+        // Whitespace
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+
+        // Style preferences
+        'single_line_throw' => false,
+        'self_accessor'     => false,
+
+        // Header
+        'header_comment' => [
+            'header'       => $header,
+            'comment_type' => 'comment',
+            'location'     => 'after_open',
+            'separate'     => 'both',
+        ],
+    ])
+    ->setFinder($finder);
+
+if (method_exists($config, 'setUnsupportedPhpVersionAllowed')) {
+    $config->setUnsupportedPhpVersionAllowed(true);
+}
+
+return $config;

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -91,5 +91,6 @@ return (new PhpCsFixer\Config())
             ->exclude('config')
             ->exclude('node_modules')
             ->exclude('var')
+            ->notPath('ext_emconf.php')
             ->in(__DIR__ . '/../')
     );

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the

--- a/Classes/Command/ClearCache.php
+++ b/Classes/Command/ClearCache.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Netresearch\Sync\Command;
 
+use function is_string;
+
 use Netresearch\Sync\Service\ClearCacheService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,14 +20,13 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-use function is_string;
-
 /**
  * The clear-cache command class.
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch http://www.netresearch.de/
- * @link    http://www.netresearch.de/
+ *
+ * @see    http://www.netresearch.de/
  */
 class ClearCache extends Command
 {
@@ -96,14 +97,14 @@ class ClearCache extends Command
             'filename',
             'f',
             InputOption::VALUE_REQUIRED,
-            'A file containing a list of table names, each line could be a comma separated list of "table:uid" entries.'
+            'A file containing a list of table names, each line could be a comma separated list of "table:uid" entries.',
         );
 
         $this->addOption(
             'data',
             'd',
             InputOption::VALUE_REQUIRED,
-            'A comma separated line of "table:uid" entries.'
+            'A comma separated line of "table:uid" entries.',
         );
     }
 

--- a/Classes/Controller/AssetSyncModuleController.php
+++ b/Classes/Controller/AssetSyncModuleController.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use Netresearch\Sync\Traits\TranslationTrait;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class AssetSyncModuleController extends BaseSyncModuleController
 {
@@ -42,7 +43,7 @@ class AssetSyncModuleController extends BaseSyncModuleController
         }
 
         $this->addMessage(
-            $this->getLabel('success.sync_assest_init')
+            $this->getLabel('success.sync_assest_init'),
         );
 
         $area->notifyMaster();

--- a/Classes/Controller/BaseSyncModuleController.php
+++ b/Classes/Controller/BaseSyncModuleController.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -56,7 +56,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class BaseSyncModuleController implements ModuleInterface
 {
@@ -331,7 +332,7 @@ class BaseSyncModuleController implements ModuleInterface
         if ($route instanceof Route) {
             $route->setOption(
                 'packageName',
-                'netresearch/nr-sync'
+                'netresearch/nr-sync',
             );
         }
     }
@@ -364,7 +365,7 @@ class BaseSyncModuleController implements ModuleInterface
 
         usort(
             $menuItems,
-            static fn (MenuItem $a, MenuItem $b): int => strtolower($a->getTitle()) <=> strtolower($b->getTitle())
+            static fn (MenuItem $a, MenuItem $b): int => strtolower($a->getTitle()) <=> strtolower($b->getTitle()),
         );
 
         $moduleMenu = $moduleTemplate->getDocHeaderComponent()->getMenuRegistry()->makeMenu();
@@ -440,14 +441,14 @@ class BaseSyncModuleController implements ModuleInterface
                             'data' => [
                                 'lock' => '0',
                             ],
-                        ]
-                    )
+                        ],
+                    ),
                 )
                 ->setIcon(
                     $this->iconFactory->getIcon(
                         'actions-lock',
-                        Icon::SIZE_SMALL
-                    )
+                        Icon::SIZE_SMALL,
+                    ),
                 )
                 ->setClasses('custom-btn-danger');
         } else {
@@ -460,14 +461,14 @@ class BaseSyncModuleController implements ModuleInterface
                             'data' => [
                                 'lock' => '1',
                             ],
-                        ]
-                    )
+                        ],
+                    ),
                 )
                 ->setIcon(
                     $this->iconFactory->getIcon(
                         'actions-unlock',
-                        Icon::SIZE_SMALL
-                    )
+                        Icon::SIZE_SMALL,
+                    ),
                 );
         }
 
@@ -513,14 +514,14 @@ class BaseSyncModuleController implements ModuleInterface
                             'lock' => [
                                 $systemName => '0',
                             ],
-                        ]
-                    )
+                        ],
+                    ),
                 )
                 ->setIcon(
                     $this->iconFactory->getIcon(
                         'actions-lock',
-                        Icon::SIZE_SMALL
-                    )
+                        Icon::SIZE_SMALL,
+                    ),
                 )
                 ->setClasses('custom-btn-danger');
         } else {
@@ -533,14 +534,14 @@ class BaseSyncModuleController implements ModuleInterface
                             'lock' => [
                                 $systemName => '1',
                             ],
-                        ]
-                    )
+                        ],
+                    ),
                 )
                 ->setIcon(
                     $this->iconFactory->getIcon(
                         'actions-unlock',
-                        Icon::SIZE_SMALL
-                    )
+                        Icon::SIZE_SMALL,
+                    ),
                 );
         }
 
@@ -595,7 +596,7 @@ class BaseSyncModuleController implements ModuleInterface
             $syncStats = GeneralUtility::makeInstance(
                 SyncStats::class,
                 GeneralUtility::makeInstance(ConnectionPool::class),
-                $this->getTables()
+                $this->getTables(),
             );
 
             $moduleTemplate->assign('tableSyncStats', $syncStats);
@@ -754,7 +755,7 @@ class BaseSyncModuleController implements ModuleInterface
             $this->area = GeneralUtility::makeInstance(
                 Area::class,
                 $this->pageUid,
-                $this->target
+                $this->target,
             );
         }
 

--- a/Classes/Controller/FalSyncModuleController.php
+++ b/Classes/Controller/FalSyncModuleController.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use Netresearch\Sync\Traits\TranslationTrait;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class FalSyncModuleController extends BaseSyncModuleController
 {
@@ -65,7 +66,7 @@ class FalSyncModuleController extends BaseSyncModuleController
                 'sys_file_reference',
                 [
                     'uid_foreign' => 0,
-                ]
+                ],
             );
 
         $this->addMessage($this->getLabel('label.done'));
@@ -89,8 +90,8 @@ class FalSyncModuleController extends BaseSyncModuleController
             ->where(
                 $queryBuilder->expr()->eq(
                     'uid_foreign',
-                    0
-                )
+                    0,
+                ),
             )
             ->executeQuery()
             ->fetchOne();

--- a/Classes/Controller/NewsSyncModuleController.php
+++ b/Classes/Controller/NewsSyncModuleController.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -21,7 +21,8 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class NewsSyncModuleController extends BaseSyncModuleController implements PageSyncModuleInterface
 {
@@ -70,13 +71,13 @@ class NewsSyncModuleController extends BaseSyncModuleController implements PageS
             ->orWhere(
                 $queryBuilder->expr()->like(
                     'list_type',
-                    $queryBuilder->createNamedParameter('%news%')
+                    $queryBuilder->createNamedParameter('%news%'),
                 ),
                 // Starting with version 11 of the news extension, the plugins are of type "CType"
                 $queryBuilder->expr()->like(
                     'CType',
-                    $queryBuilder->createNamedParameter('%news%')
-                )
+                    $queryBuilder->createNamedParameter('%news%'),
+                ),
             )
             ->groupBy('pid');
 

--- a/Classes/Controller/SinglePageSyncModuleController.php
+++ b/Classes/Controller/SinglePageSyncModuleController.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -22,7 +22,8 @@ use TYPO3\CMS\Core\Domain\Repository\PageRepository;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class SinglePageSyncModuleController extends BaseSyncModuleController implements SinglePageSyncModuleInterface
 {
@@ -69,8 +70,8 @@ class SinglePageSyncModuleController extends BaseSyncModuleController implements
                     'error.page_not_load',
                     [
                         '{page_selected}' => $this->pageUid,
-                    ]
-                )
+                    ],
+                ),
             );
 
             return;
@@ -86,7 +87,7 @@ class SinglePageSyncModuleController extends BaseSyncModuleController implements
         $recursion   = (int) $this
             ->getBackendUserAuthentication()
             ->getSessionData(
-                'nr_sync_synclist_levelmax' . $this->getSyncList()->getId()
+                'nr_sync_synclist_levelmax' . $this->getSyncList()->getId(),
             );
 
         if (isset($_POST['data']['recursion'])) {
@@ -109,7 +110,7 @@ class SinglePageSyncModuleController extends BaseSyncModuleController implements
                 $arCount,
                 0,
                 $recursion,
-                $tables
+                $tables,
             );
 
         $strTitle = $this->getArea()->getName() . ' - ' . $record['uid'] . ' - ' . $record['title'];
@@ -138,7 +139,7 @@ class SinglePageSyncModuleController extends BaseSyncModuleController implements
             $this->moduleTemplate->assign('recursion', $recursion);
         } else {
             $this->addErrorMessage(
-                $this->getLabel('error.select_mark_type')
+                $this->getLabel('error.select_mark_type'),
             );
         }
     }
@@ -155,7 +156,7 @@ class SinglePageSyncModuleController extends BaseSyncModuleController implements
             if (isset($_POST['data']['type'])) {
                 $this->getSyncList()
                     ->addToSyncList(
-                        $_POST['data']
+                        $_POST['data'],
                     );
             } else {
                 $this->addErrorMessage($this->getLabel('error.select_mark_type'));

--- a/Classes/Controller/TableStateSyncModuleController.php
+++ b/Classes/Controller/TableStateSyncModuleController.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -22,7 +22,8 @@ use Netresearch\Sync\Traits\TranslationTrait;
  * @author  Sebastian Mendel <sebastian.mendel@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class TableStateSyncModuleController extends BaseSyncModuleController
 {
@@ -42,7 +43,7 @@ class TableStateSyncModuleController extends BaseSyncModuleController
         if (isset($_POST['data']['submit'])) {
             if ($this->createNewDefinitions()) {
                 $this->addSuccessMessage(
-                    $this->getLabel('message.table_state_success')
+                    $this->getLabel('message.table_state_success'),
                 );
             }
         } else {
@@ -89,8 +90,8 @@ class TableStateSyncModuleController extends BaseSyncModuleController
             $defaultFolder->createFile(
                 $this->tableSerializedFile,
                 $defaultFolder->getFolder(
-                    $this->storageService->getBaseFolderIdentifier()
-                )
+                    $this->storageService->getBaseFolderIdentifier(),
+                ),
             );
         }
 

--- a/Classes/Event/AfterSyncEvent.php
+++ b/Classes/Event/AfterSyncEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -17,7 +17,8 @@ namespace Netresearch\Sync\Event;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class AfterSyncEvent
 {
@@ -34,8 +35,7 @@ final class AfterSyncEvent
         private readonly string $dumpFile,
         private readonly ?string $targetName,
         private readonly bool $success,
-    ) {
-    }
+    ) {}
 
     /**
      * @return array<int, string>

--- a/Classes/Event/BeforeSyncEvent.php
+++ b/Classes/Event/BeforeSyncEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -17,7 +17,8 @@ namespace Netresearch\Sync\Event;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class BeforeSyncEvent
 {
@@ -32,8 +33,7 @@ final class BeforeSyncEvent
         private array $tables,
         private readonly string $dumpFile,
         private readonly ?string $targetName = null,
-    ) {
-    }
+    ) {}
 
     /**
      * @return array<int, string>

--- a/Classes/Event/FalSyncEvent.php
+++ b/Classes/Event/FalSyncEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -16,7 +16,8 @@ namespace Netresearch\Sync\Event;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class FalSyncEvent
 {
@@ -29,8 +30,7 @@ final class FalSyncEvent
     public function __construct(
         private readonly int $areaId,
         private readonly string $dumpFilePrefix,
-    ) {
-    }
+    ) {}
 
     /**
      * @return int

--- a/Classes/Event/ModifyMenuItemsEvent.php
+++ b/Classes/Event/ModifyMenuItemsEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3\CMS\Backend\Template\Components\Menu\MenuItem;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class ModifyMenuItemsEvent
 {
@@ -32,8 +33,7 @@ final class ModifyMenuItemsEvent
     public function __construct(
         private array $menuItems,
         private readonly string $currentModuleIdentifier,
-    ) {
-    }
+    ) {}
 
     /**
      * @return array<int, MenuItem>

--- a/Classes/Event/ModifyTableListEvent.php
+++ b/Classes/Event/ModifyTableListEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -17,7 +17,8 @@ namespace Netresearch\Sync\Event;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class ModifyTableListEvent
 {
@@ -30,8 +31,7 @@ final class ModifyTableListEvent
     public function __construct(
         private array $tables,
         private readonly string $moduleIdentifier,
-    ) {
-    }
+    ) {}
 
     /**
      * @return array<int, string>

--- a/Classes/EventListener/FalSyncEventListener.php
+++ b/Classes/EventListener/FalSyncEventListener.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -24,7 +24,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class FalSyncEventListener
 {
@@ -51,8 +52,8 @@ class FalSyncEventListener
         $syncModule->setModuleData(
             ModuleData::createFromModule(
                 $module,
-                $module->getDefaultModuleData()
-            )
+                $module->getDefaultModuleData(),
+            ),
         );
         $syncModule->initFolders($area);
 
@@ -74,7 +75,7 @@ class FalSyncEventListener
             $syncModule->createDumpToAreas(
                 $syncModule->getTables(),
                 $event->getDumpFilePrefix() . '-' . $dumpFile,
-                $key
+                $key,
             );
         }
     }

--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -17,8 +17,7 @@ namespace Netresearch\Sync;
  * @author  Alexander Opitz <alexander.opitz@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
-class Exception extends \Exception
-{
-}
+class Exception extends \Exception {}

--- a/Classes/Generator/Urls.php
+++ b/Classes/Generator/Urls.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -11,13 +11,13 @@ declare(strict_types=1);
 
 namespace Netresearch\Sync\Generator;
 
+use function count;
+
 use Netresearch\Sync\Controller\BaseSyncModuleController;
 use Netresearch\Sync\Helper\Area;
 use Netresearch\Sync\Service\StorageService;
 use Netresearch\Sync\Traits\TranslationTrait;
 use TYPO3\CMS\Core\Resource\FileInterface;
-
-use function count;
 
 /**
  * Generate files with the list of URLs that have to be called
@@ -26,7 +26,8 @@ use function count;
  * @author  Christian Weiske <christian.weiske@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class Urls
 {
@@ -87,7 +88,7 @@ class Urls
             $count = $this->generateUrlFile(
                 $params['arUrlsOnce'],
                 $folders,
-                self::FILE_FORMAT_ONCE
+                self::FILE_FORMAT_ONCE,
             );
         }
 
@@ -95,7 +96,7 @@ class Urls
             $count += $this->generateUrlFile(
                 $params['arUrlsPerMachine'],
                 $folders,
-                self::FILE_FORMAT_PERMACHINE
+                self::FILE_FORMAT_PERMACHINE,
             );
         }
 
@@ -104,8 +105,8 @@ class Urls
                 'message.hook_files',
                 [
                     '{number}' => $count,
-                ]
-            )
+                ],
+            ),
         );
     }
 
@@ -202,8 +203,8 @@ class Urls
                             'warning.urls_system_locked',
                             [
                                 '{target}' => $system['directory'],
-                            ]
-                        )
+                            ],
+                        ),
                     );
 
                     continue;

--- a/Classes/Helper/Area.php
+++ b/Classes/Helper/Area.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Netresearch\Sync\Helper;
 
+use function in_array;
+
 use Netresearch\Sync\Exception;
 use Netresearch\Sync\Traits\FlashMessageTrait;
 use Netresearch\Sync\Traits\TranslationTrait;
@@ -19,15 +21,14 @@ use TYPO3\CMS\Core\Core\ApplicationContext;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-use function in_array;
-
 /**
  * Methods to work with synchronization areas.
  *
  * @author  Christian Weiske <christian.weiske@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class Area
 {
@@ -322,8 +323,8 @@ class Area
                             'message.notify_success',
                             [
                                 '{target}' => $system['name'],
-                            ]
-                        )
+                            ],
+                        ),
                     );
                 } catch (\Exception) {
                     $this->addErrorMessage(
@@ -331,8 +332,8 @@ class Area
                             'message.notify_failed',
                             [
                                 '{target}' => $system['name'],
-                            ]
-                        )
+                            ],
+                        ),
                     );
                 }
             } else {
@@ -342,8 +343,8 @@ class Area
                         [
                             '{target}'      => $system['name'],
                             '{notify_type}' => $system['notify']['type'],
-                        ]
-                    )
+                        ],
+                    ),
                 );
             }
         }
@@ -378,8 +379,8 @@ class Area
                     'message.notify_disabled',
                     [
                         '{target}' => $system['name'],
-                    ]
-                )
+                    ],
+                ),
             );
 
             return false;
@@ -399,8 +400,8 @@ class Area
                 [
                     '{target}'           => $system['name'],
                     '{allowed_contexts}' => implode(', ', $system['notify']['contexts']),
-                ]
-            )
+                ],
+            ),
         );
 
         return false;

--- a/Classes/Middleware/ClearCache.php
+++ b/Classes/Middleware/ClearCache.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -26,7 +26,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class ClearCache implements MiddlewareInterface
 {

--- a/Classes/ModuleInterface.php
+++ b/Classes/ModuleInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -18,7 +18,8 @@ use Netresearch\Sync\Helper\Area;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 interface ModuleInterface
 {

--- a/Classes/PageSyncModuleInterface.php
+++ b/Classes/PageSyncModuleInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -16,7 +16,8 @@ namespace Netresearch\Sync;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 interface PageSyncModuleInterface
 {

--- a/Classes/Scheduler/SyncImportTask/AdditionalFieldsProvider.php
+++ b/Classes/Scheduler/SyncImportTask/AdditionalFieldsProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -21,7 +21,8 @@ use TYPO3\CMS\Scheduler\Task\AbstractTask;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class AdditionalFieldsProvider extends AbstractAdditionalFieldProvider
 {

--- a/Classes/Scheduler/SyncImportTask/Task.php
+++ b/Classes/Scheduler/SyncImportTask/Task.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -10,6 +10,8 @@
 declare(strict_types=1);
 
 namespace Netresearch\Sync\Scheduler\SyncImportTask;
+
+use function is_array;
 
 use Netresearch\NrScheduler\AbstractTask;
 use Netresearch\Sync\Service\ClearCacheService;
@@ -22,15 +24,14 @@ use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsExcepti
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-use function is_array;
-
 /**
  * Scheduler task to import the sync MyQSL files.
  *
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class Task extends AbstractTask
 {
@@ -109,7 +110,7 @@ class Task extends AbstractTask
                 $databaseConnection->getParams()['user'],
                 $databaseConnection->getParams()['password'],
                 $databaseConnection->getParams()['dbname'],
-                $tmpFile
+                $tmpFile,
             );
 
             $output = [];

--- a/Classes/Service/ClearCacheService.php
+++ b/Classes/Service/ClearCacheService.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -23,7 +23,8 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class ClearCacheService implements LoggerAwareInterface
 {
@@ -93,7 +94,7 @@ class ClearCacheService implements LoggerAwareInterface
                     'Clear cache failed with message: ' . $throwable->getMessage(),
                     [
                         'exception' => $throwable,
-                    ]
+                    ],
                 );
             }
 

--- a/Classes/Service/StorageService.php
+++ b/Classes/Service/StorageService.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -26,7 +26,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class StorageService
 {

--- a/Classes/SinglePageSyncModuleInterface.php
+++ b/Classes/SinglePageSyncModuleInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -16,8 +16,7 @@ namespace Netresearch\Sync;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
-interface SinglePageSyncModuleInterface
-{
-}
+interface SinglePageSyncModuleInterface {}

--- a/Classes/SyncList.php
+++ b/Classes/SyncList.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -12,6 +12,10 @@ declare(strict_types=1);
 namespace Netresearch\Sync;
 
 use Doctrine\DBAL\Exception;
+
+use function in_array;
+use function is_array;
+
 use Netresearch\Sync\Helper\Area;
 use Netresearch\Sync\Traits\FlashMessageTrait;
 use Netresearch\Sync\Traits\TranslationTrait;
@@ -23,16 +27,14 @@ use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-use function in_array;
-use function is_array;
-
 /**
  * Class SyncList.
  *
  * @author  Sebastian Mendel <sebastian.mendel@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class SyncList
 {
@@ -114,7 +116,7 @@ class SyncList
         ) {
             $this->addMessage(
                 $this->getLabel('error.page_is_marked'),
-                ContextualFeedbackSeverity::ERROR
+                ContextualFeedbackSeverity::ERROR,
             );
         } else {
             $this->syncList[(int) $data['areaID']][] = $data;
@@ -229,7 +231,7 @@ class SyncList
                 /** @var Area $area */
                 $area = GeneralUtility::makeInstance(
                     Area::class,
-                    (int) $syncPage['areaID']
+                    (int) $syncPage['areaID'],
                 );
 
                 $arCount = $this->getSubpagesAndCount(
@@ -237,7 +239,7 @@ class SyncList
                     $area,
                     $dummy,
                     0,
-                    (int) $syncPage['levelmax']
+                    (int) $syncPage['levelmax'],
                 );
 
                 $pageIds[] = $this->getPageIDsFromTree($arCount);
@@ -318,7 +320,7 @@ class SyncList
             ->select('*')
             ->from('pages')
             ->where(
-                $queryBuilder->expr()->eq('pid', $pid)
+                $queryBuilder->expr()->eq('pid', $pid),
             )
             ->executeQuery();
 
@@ -345,7 +347,7 @@ class SyncList
                 $arCount,
                 $level + 1,
                 $levelMax,
-                $tables
+                $tables,
             );
 
             if ($this->getBackendUserAuthentication()->doesUserHaveAccess($pageRow, Permission::PAGE_EDIT)) {

--- a/Classes/SyncListManager.php
+++ b/Classes/SyncListManager.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author  Sebastian Mendel <sebastian.mendel@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class SyncListManager implements SingletonInterface
 {

--- a/Classes/SyncLock.php
+++ b/Classes/SyncLock.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -22,7 +22,8 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
  * @author  Sebastian Mendel <sebastian.mendel@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class SyncLock
 {
@@ -64,7 +65,9 @@ class SyncLock
             throw new RuntimeException(
                 'Error in nr_sync configuration: '
                 . $exception->getMessage()
-                . ' Please check configuration in the Extension Manager.', $exception->getCode(), $exception
+                . ' Please check configuration in the Extension Manager.',
+                $exception->getCode(),
+                $exception,
             );
         }
     }

--- a/Classes/SyncStats.php
+++ b/Classes/SyncStats.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  * @author  Sebastian Mendel <sebastian.mendel@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class SyncStats
 {
@@ -67,8 +68,8 @@ class SyncStats
             ->where(
                 $queryBuilder->expr()->eq(
                     'tab',
-                    $queryBuilder->quote('*')
-                )
+                    $queryBuilder->quote('*'),
+                ),
             )
             ->executeQuery()
             ->fetchAssociative();
@@ -99,8 +100,8 @@ class SyncStats
                 ->where(
                     $queryBuilder->expr()->eq(
                         'tab',
-                        $queryBuilder->quote($table)
-                    )
+                        $queryBuilder->quote($table),
+                    ),
                 )
                 ->executeQuery()
                 ->fetchAssociative();

--- a/Classes/Table.php
+++ b/Classes/Table.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -12,6 +12,9 @@ declare(strict_types=1);
 namespace Netresearch\Sync;
 
 use Doctrine\DBAL\Exception;
+
+use function in_array;
+
 use Netresearch\Sync\Service\StorageService;
 use Netresearch\Sync\Traits\FlashMessageTrait;
 use Netresearch\Sync\Traits\TranslationTrait;
@@ -21,15 +24,14 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-use function in_array;
-
 /**
  * Controls table sync/dump generation.
  *
  * @author  Sebastian Mendel <sebastian.mendel@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class Table
 {
@@ -142,8 +144,8 @@ class Table
     private function appendToDumpFile(string $content): void
     {
         $this->getDumpFile()->setContents(
-            $this->getDumpFile()->getContents() .
-            PHP_EOL . $content . PHP_EOL
+            $this->getDumpFile()->getContents()
+            . PHP_EOL . $content . PHP_EOL,
         );
     }
 
@@ -162,7 +164,7 @@ class Table
         return in_array(
             $this->tableName,
             $this->arTablesUsingReplacetatement,
-            true
+            true,
         );
     }
 
@@ -235,8 +237,8 @@ class Table
                 'message.notify_skipped_table',
                 [
                     '{table}' => $this->tableName,
-                ]
-            )
+                ],
+            ),
         );
     }
 
@@ -258,7 +260,7 @@ class Table
         if ($strWhere === '' || $strWhere === false) {
             throw new Exception(
                 'Could not get WHERE condition for tstamp field for table "'
-                . $this->tableName . '".'
+                . $this->tableName . '".',
             );
         }
 
@@ -386,7 +388,7 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
         if ($strWhere === '' || $strWhere === false) {
             throw new Exception(
                 'Could not get WHERE condition for tstamp field for table "'
-                . $this->tableName . '".'
+                . $this->tableName . '".',
             );
         }
 
@@ -494,11 +496,11 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
         $arRow = $queryBuilder
             ->selectLiteral(
                 'max(' . $queryBuilder->quoteIdentifier('incr') . ') AS ' . $queryBuilder->quoteIdentifier('incr'),
-                'max(' . $queryBuilder->quoteIdentifier('full') . ') AS ' . $queryBuilder->quoteIdentifier('full')
+                'max(' . $queryBuilder->quoteIdentifier('full') . ') AS ' . $queryBuilder->quoteIdentifier('full'),
             )
             ->from('tx_nrsync_syncstat')
             ->where(
-                $queryBuilder->expr()->in('tab', [$queryBuilder->quote('*'), $queryBuilder->quote($this->tableName)])
+                $queryBuilder->expr()->in('tab', [$queryBuilder->quote('*'), $queryBuilder->quote($this->tableName)]),
             )
             ->executeQuery()
             ->fetchAssociative();
@@ -559,8 +561,8 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
                 $connection->quote($nUserId),
                 $connection->quote($nUserId),
                 $strUpdateField,
-                $connection->quote($nTime)
-            )
+                $connection->quote($nTime),
+            ),
         );
     }
 
@@ -583,7 +585,7 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
 
         // date to compare end timestamp with
         $nToday = strtotime(
-            date('Y-m-d')
+            date('Y-m-d'),
         );
 
         $strStatement = 'DELETE FROM '

--- a/Classes/Traits/DatabaseConnectionTrait.php
+++ b/Classes/Traits/DatabaseConnectionTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -23,7 +23,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 trait DatabaseConnectionTrait
 {

--- a/Classes/Traits/DumpFileTrait.php
+++ b/Classes/Traits/DumpFileTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -11,7 +11,12 @@ declare(strict_types=1);
 
 namespace Netresearch\Sync\Traits;
 
+use function count;
+
 use Doctrine\DBAL\Exception;
+
+use function is_array;
+
 use Netresearch\Sync\Event\AfterSyncEvent;
 use Netresearch\Sync\Event\BeforeSyncEvent;
 use Netresearch\Sync\Helper\Area;
@@ -19,14 +24,13 @@ use Netresearch\Sync\PageSyncModuleInterface;
 use Netresearch\Sync\Table;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use RuntimeException;
+
+use function sprintf;
+
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\Folder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-
-use function count;
-use function is_array;
-use function sprintf;
 
 /**
  * DumpFileTrait.
@@ -34,7 +38,8 @@ use function sprintf;
  * @author  Sebastian Mendel <sebastian.mendel@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 trait DumpFileTrait
 {
@@ -86,7 +91,7 @@ trait DumpFileTrait
                     $area = GeneralUtility::makeInstance(
                         Area::class,
                         $areaId,
-                        $this->target
+                        $this->target,
                     );
 
                     $pageIds = $syncList->getAllPageIDs($areaId);
@@ -95,14 +100,14 @@ trait DumpFileTrait
                         $pageIds,
                         $this->getTables(),
                         $dumpFileArea,
-                        $area->getDirectories()
+                        $area->getDirectories(),
                     );
 
                     if ($ret && $this->createClearCacheFile('pages', $pageIds)) {
                         $area->notifyMaster();
 
                         $this->addSuccessMessage(
-                            $this->getLabel('success.sync_in_progress')
+                            $this->getLabel('success.sync_in_progress'),
                         );
 
                         $syncList->emptyArea($areaId);
@@ -113,7 +118,7 @@ trait DumpFileTrait
         } else {
             $syncResult = $this->createDumpToAreas(
                 $this->getTables(),
-                $dumpFile
+                $dumpFile,
             );
 
             // Create page sync files for pages which have related pages.
@@ -122,7 +127,7 @@ trait DumpFileTrait
             ) {
                 $this->createClearCacheFile(
                     'pages',
-                    $this->getPagesToSync()
+                    $this->getPagesToSync(),
                 );
             }
 
@@ -137,7 +142,7 @@ trait DumpFileTrait
 
             if ($syncResult) {
                 $this->addSuccessMessage(
-                    $this->getLabel('success.sync_initiated')
+                    $this->getLabel('success.sync_initiated'),
                 );
             }
         }
@@ -183,7 +188,7 @@ trait DumpFileTrait
             [],
             [],
             $fpDumpFile,
-            $this->getDeleteRowStatements()
+            $this->getDeleteRowStatements(),
         );
 
         $this->writeInsertLines($fpDumpFile);
@@ -267,8 +272,8 @@ trait DumpFileTrait
                         'warning.system_locked',
                         [
                             '{system}' => $path,
-                        ]
-                    )
+                        ],
+                    ),
                 );
 
                 continue;
@@ -317,7 +322,7 @@ trait DumpFileTrait
             || $tempStorage->hasFile($tempFileIdentifier . '.gz')
         ) {
             $this->addErrorMessage(
-                $this->getLabel('error.last_sync_not_finished')
+                $this->getLabel('error.last_sync_not_finished'),
             );
 
             return false;
@@ -331,7 +336,7 @@ trait DumpFileTrait
             [
                 'forceFullSync'      => isset($_POST['data']['force_full_sync']) && ($_POST['data']['force_full_sync'] === '1'),
                 'deleteObsoleteRows' => isset($_POST['data']['delete_obsolete_rows']) && ($_POST['data']['delete_obsolete_rows'] === '1'),
-            ]
+            ],
         );
 
         $dumpFile = null;
@@ -340,12 +345,12 @@ trait DumpFileTrait
             $dumpFile = $tempStorage->getFile($tempFileIdentifier);
         } catch (\Exception) {
             $this->addInfoMessage(
-                $this->getLabel('info.no_data_dumped')
+                $this->getLabel('info.no_data_dumped'),
             );
         } finally {
             if ($dumpFile === null) {
                 $this->addInfoMessage(
-                    $this->getLabel('info.no_data_dumped')
+                    $this->getLabel('info.no_data_dumped'),
                 );
 
                 // Dispatch AfterSyncEvent with failure
@@ -364,8 +369,8 @@ trait DumpFileTrait
                     'error.zip_failure',
                     [
                         '{file}' => $dumpFile->getIdentifier(),
-                    ]
-                )
+                    ],
+                ),
             );
 
             // Dispatch AfterSyncEvent with failure
@@ -400,8 +405,8 @@ trait DumpFileTrait
                             [
                                 '{file}'   => $compressedDumFile->getIdentifier(),
                                 '{target}' => $targetFolder->getIdentifier() . $targetFilename . '.gz',
-                            ]
-                        )
+                            ],
+                        ),
                     );
 
                     // Dispatch AfterSyncEvent with failure
@@ -447,8 +452,8 @@ trait DumpFileTrait
             $compressedDumpFile?->setContents(
                 gzencode(
                     $dumpFile instanceof FileInterface ? $dumpFile->getContents() : '',
-                    9
-                )
+                    9,
+                ),
             );
 
             $tempStorage->deleteFile($dumpFile);
@@ -458,8 +463,8 @@ trait DumpFileTrait
                     'error.zip_failure',
                     [
                         '{file}' => isset($dumpFile) ? $dumpFile->getIdentifier() : '',
-                    ]
-                )
+                    ],
+                ),
             );
 
             return null;
@@ -498,7 +503,7 @@ trait DumpFileTrait
                 'bProcess'    => true,
                 'bSyncResult' => true,
             ],
-            $this
+            $this,
         );
 
         return true;
@@ -526,7 +531,7 @@ trait DumpFileTrait
             throw new Exception(
                 $this->getLabel('error.last_sync_not_finished')
                 . "<br/>\n"
-                . $tempFileIdentifier . '(.gz)'
+                . $tempFileIdentifier . '(.gz)',
             );
         }
 
@@ -539,7 +544,7 @@ trait DumpFileTrait
                 || $defaultStorage->hasFile($fileIdentifier . '.gz')
             ) {
                 throw new Exception(
-                    $this->getLabel('error.last_sync_not_finished')
+                    $this->getLabel('error.last_sync_not_finished'),
                 );
             }
         }
@@ -587,8 +592,8 @@ trait DumpFileTrait
                     'error.mm_tables',
                     [
                         '{tableName}' => $tableName,
-                    ]
-                )
+                    ],
+                ),
             );
         }
 
@@ -720,7 +725,7 @@ trait DumpFileTrait
         return sprintf(
             'DELETE FROM %s WHERE uid = %d;',
             $connection->quoteIdentifier($tableName),
-            $uid
+            $uid,
         );
     }
 
@@ -746,7 +751,7 @@ trait DumpFileTrait
             // TYPO-2215 - Match the column to its update value
             $updateParts[$key] = sprintf(
                 '%1$s = VALUES(%1$s)',
-                $connection->quoteIdentifier($key)
+                $connection->quoteIdentifier($key),
             );
         }
 
@@ -755,7 +760,7 @@ trait DumpFileTrait
             $connection->quoteIdentifier($tableName),
             implode(', ', $connection->quoteIdentifiers($columnNames)),
             implode(', ', $row),
-            implode(', ', $updateParts)
+            implode(', ', $updateParts),
         );
     }
 
@@ -794,7 +799,7 @@ trait DumpFileTrait
                     $row['uid'],
                     $arMMConfig,
                     $columnNames,
-                    $fpDumpFile
+                    $fpDumpFile,
                 );
             }
         }
@@ -925,7 +930,7 @@ trait DumpFileTrait
             $deleteLines[$tableName][$uid] = sprintf(
                 'DELETE FROM %s WHERE %s;',
                 $connection->quoteIdentifier($tableName),
-                $strWhere
+                $strWhere,
             );
         }
 
@@ -952,7 +957,7 @@ trait DumpFileTrait
                     ],
                     'sys_file',
                     $fpDumpFile,
-                    true
+                    true,
                 );
             }
         }
@@ -979,19 +984,19 @@ trait DumpFileTrait
         // Remove Deletes which has a corresponding Insert statement
         $this->diffDeleteLinesAgainstInsertLines(
             $deleteLines,
-            $insertLines
+            $insertLines,
         );
 
         // Remove all DELETE Lines that already has been put to file
         $this->clearDuplicateLines(
             'delete',
-            $deleteLines
+            $deleteLines,
         );
 
         // Remove all INSERT Lines that already has been put to file
         $this->clearDuplicateLines(
             'insert',
-            $insertLines
+            $insertLines,
         );
 
         $this->writeToDumpFile($deleteLines, $insertLines, $fpDumpFile);
@@ -1084,7 +1089,7 @@ trait DumpFileTrait
             ->from('tx_nrsync_syncstat')
             ->where(
                 $queryBuilder->expr()->eq('tab', $queryBuilder->quote($table)),
-                $queryBuilder->expr()->eq('uid_foreign', $uid)
+                $queryBuilder->expr()->eq('uid_foreign', $uid),
             )
             ->executeQuery()
             ->fetchAssociative();
@@ -1106,7 +1111,7 @@ trait DumpFileTrait
             ->select('tstamp')
             ->from($table)
             ->where(
-                $queryBuilder->expr()->eq('uid', $uid)
+                $queryBuilder->expr()->eq('uid', $uid),
             )
             ->executeQuery()
             ->fetchOne();
@@ -1305,8 +1310,8 @@ trait DumpFileTrait
                 $connection->quote($uid),
                 $connection->quote($userId),
                 $updateField,
-                $connection->quote($time)
-            )
+                $connection->quote($time),
+            ),
         );
     }
 }

--- a/Classes/Traits/FlashMessageTrait.php
+++ b/Classes/Traits/FlashMessageTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -22,7 +22,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * @author  Sebastian Mendel <sebastian.mendel@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 trait FlashMessageTrait
 {
@@ -44,7 +45,7 @@ trait FlashMessageTrait
             $message,
             $title,
             $severity,
-            true
+            true,
         );
 
         /** @var FlashMessageService $flashMessageService */

--- a/Classes/Traits/SyncTargetLockTrait.php
+++ b/Classes/Traits/SyncTargetLockTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -17,7 +17,8 @@ namespace Netresearch\Sync\Traits;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 trait SyncTargetLockTrait
 {
@@ -51,14 +52,14 @@ trait SyncTargetLockTrait
                         'message.target_locked',
                         [
                             '{target}' => $systemName,
-                        ]
-                    )
+                        ],
+                    ),
                 );
             } elseif ($defaultStorage->hasFile($systemDirectory->getIdentifier() . '.lock')) {
                 $defaultStorage
                     ->deleteFile(
                         $defaultStorage
-                            ->getFile($systemDirectory->getIdentifier() . '.lock')
+                            ->getFile($systemDirectory->getIdentifier() . '.lock'),
                     );
 
                 $this->addInfoMessage(
@@ -66,8 +67,8 @@ trait SyncTargetLockTrait
                         'message.target_unlocked',
                         [
                             '{target}' => $systemName,
-                        ]
-                    )
+                        ],
+                    ),
                 );
             }
         }

--- a/Classes/Traits/TableDifferenceTrait.php
+++ b/Classes/Traits/TableDifferenceTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use Doctrine\DBAL\Exception;
  * @author  Alexander Opitz <alexander.opitz@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 trait TableDifferenceTrait
 {
@@ -59,7 +60,7 @@ trait TableDifferenceTrait
         if ($errorTables !== []) {
             $this->addWarningMessage(
                 $this->getLabel('warning.table_state')
-                . "\n\n" . implode(', ', $errorTables)
+                . "\n\n" . implode(', ', $errorTables),
             );
         }
     }

--- a/Classes/Traits/TranslationTrait.php
+++ b/Classes/Traits/TranslationTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3\CMS\Core\Localization\LanguageService;
  * @author  Axel Seemann <axel.seemann@netresearch.de>
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 trait TranslationTrait
 {
@@ -51,7 +52,7 @@ trait TranslationTrait
         }
 
         $translation = $this->getLanguageService()->sL(
-            $languageFile . ':' . $id
+            $languageFile . ':' . $id,
         );
 
         if ($translation === '') {
@@ -74,9 +75,9 @@ trait TranslationTrait
         $data = array_combine(
             array_merge(
                 $data,
-                $keyReplacements
+                $keyReplacements,
             ),
-            $data
+            $data,
         );
 
         return str_replace(array_keys($data), $data, $translation);

--- a/Classes/ViewHelpers/AreaViewHelper.php
+++ b/Classes/ViewHelpers/AreaViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class AreaViewHelper extends AbstractViewHelper
 {
@@ -35,7 +36,7 @@ class AreaViewHelper extends AbstractViewHelper
             'id',
             'int',
             'The area id',
-            true
+            true,
         );
     }
 

--- a/Classes/ViewHelpers/Backend/RecordTitleViewHelper.php
+++ b/Classes/ViewHelpers/Backend/RecordTitleViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class RecordTitleViewHelper extends AbstractViewHelper
 {
@@ -34,7 +35,7 @@ class RecordTitleViewHelper extends AbstractViewHelper
             'pid',
             'int',
             'The page id',
-            true
+            true,
         );
     }
 
@@ -47,7 +48,7 @@ class RecordTitleViewHelper extends AbstractViewHelper
     {
         return BackendUtility::getRecordTitle(
             'pages',
-            BackendUtility::getRecord('pages', $this->arguments['pid'])
+            BackendUtility::getRecord('pages', $this->arguments['pid']),
         );
     }
 }

--- a/Classes/ViewHelpers/Backend/UriViewHelper.php
+++ b/Classes/ViewHelpers/Backend/UriViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -21,7 +21,8 @@ use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class UriViewHelper extends AbstractBackendViewHelper
 {
@@ -36,28 +37,28 @@ class UriViewHelper extends AbstractBackendViewHelper
             'route',
             'string',
             'The name of the route',
-            true
+            true,
         );
 
         $this->registerArgument(
             'pid',
             'int',
             'The page UID',
-            true
+            true,
         );
 
         $this->registerArgument(
             'area',
             'string',
             'The area name to lock/unlock',
-            true
+            true,
         );
 
         $this->registerArgument(
             'lock',
             'int',
             '1 or 0 to lock/unlock the area',
-            true
+            true,
         );
     }
 
@@ -78,7 +79,7 @@ class UriViewHelper extends AbstractBackendViewHelper
                     'lock' => [
                         $this->arguments['area'] => $this->arguments['lock'],
                     ],
-                ]
+                ],
             );
     }
 }

--- a/Classes/ViewHelpers/File/BasenameViewHelper.php
+++ b/Classes/ViewHelpers/File/BasenameViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -18,7 +18,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class BasenameViewHelper extends AbstractViewHelper
 {
@@ -33,7 +34,7 @@ class BasenameViewHelper extends AbstractViewHelper
             'file',
             'string',
             'The name and path to the file',
-            true
+            true,
         );
     }
 

--- a/Classes/ViewHelpers/File/ModifiedTimeViewHelper.php
+++ b/Classes/ViewHelpers/File/ModifiedTimeViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -18,7 +18,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class ModifiedTimeViewHelper extends AbstractViewHelper
 {
@@ -33,7 +34,7 @@ class ModifiedTimeViewHelper extends AbstractViewHelper
             'file',
             'string',
             'The name and path to the file',
-            true
+            true,
         );
     }
 

--- a/Classes/ViewHelpers/FlashMessageViewHelper.php
+++ b/Classes/ViewHelpers/FlashMessageViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -11,20 +11,21 @@ declare(strict_types=1);
 
 namespace Netresearch\Sync\ViewHelpers;
 
+use function constant;
+
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\Renderer\BootstrapRenderer;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
-use function constant;
-
 /**
  * A ViewHelper to print return an area by a given areaId.
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class FlashMessageViewHelper extends AbstractViewHelper
 {
@@ -65,7 +66,7 @@ class FlashMessageViewHelper extends AbstractViewHelper
             'type',
             'int',
             'The flash message type (either NOTICE, INFO, OK, WARNING or ERROR)',
-            true
+            true,
         );
     }
 
@@ -81,7 +82,7 @@ class FlashMessageViewHelper extends AbstractViewHelper
             FlashMessage::class,
             trim((string) $this->renderChildren()),
             '',
-            constant(ContextualFeedbackSeverity::class . '::' . $this->arguments['type'])
+            constant(ContextualFeedbackSeverity::class . '::' . $this->arguments['type']),
         );
 
         return $this->bootstrapRenderer->render([$message]);

--- a/Classes/ViewHelpers/Folder/FilesViewHelper.php
+++ b/Classes/ViewHelpers/Folder/FilesViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -25,7 +25,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class FilesViewHelper extends AbstractViewHelper
 {
@@ -40,7 +41,7 @@ class FilesViewHelper extends AbstractViewHelper
             'directory',
             'string',
             'The name and path to the lock file directory',
-            true
+            true,
         );
     }
 
@@ -74,9 +75,9 @@ class FilesViewHelper extends AbstractViewHelper
                     $itemIdentifier,
                     $parentIdentifier,
                     $additionalInformation,
-                    $driver
+                    $driver,
                 ),
-            ]
+            ],
         );
 
         return $subFolder->getFiles();

--- a/Classes/ViewHelpers/Folder/LockFileExistsViewHelper.php
+++ b/Classes/ViewHelpers/Folder/LockFileExistsViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -22,7 +22,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class LockFileExistsViewHelper extends AbstractViewHelper
 {
@@ -37,7 +38,7 @@ class LockFileExistsViewHelper extends AbstractViewHelper
             'directory',
             'string',
             'The name and path to the lock file directory',
-            true
+            true,
         );
     }
 

--- a/Classes/ViewHelpers/Format/UsernameViewHelper.php
+++ b/Classes/ViewHelpers/Format/UsernameViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -19,7 +19,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class UsernameViewHelper extends AbstractViewHelper
 {
@@ -34,7 +35,7 @@ class UsernameViewHelper extends AbstractViewHelper
             'id',
             'int',
             'The UID of the user',
-            true
+            true,
         );
     }
 

--- a/Classes/ViewHelpers/Math/CeilViewHelper.php
+++ b/Classes/ViewHelpers/Math/CeilViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -18,7 +18,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class CeilViewHelper extends AbstractViewHelper
 {
@@ -32,7 +33,7 @@ class CeilViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'value',
             'mixed',
-            'The number to process'
+            'The number to process',
         );
     }
 

--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 class TranslateViewHelper extends AbstractViewHelper
 {
@@ -36,13 +37,13 @@ class TranslateViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'key',
             'string',
-            'The Translation key'
+            'The Translation key',
         );
 
         $this->registerArgument(
             'id',
             'string',
-            'The Translation ID. Same as key.'
+            'The Translation ID. Same as key.',
         );
 
         $this->registerArgument(
@@ -69,7 +70,7 @@ class TranslateViewHelper extends AbstractViewHelper
 
         return $this->getLabel(
             $id,
-            $this->arguments['data'] ?? []
+            $this->arguments['data'] ?? [],
         );
     }
 }

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the

--- a/Configuration/DefaultAreaConfiguration.php
+++ b/Configuration/DefaultAreaConfiguration.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the

--- a/Tests/Unit/Event/AfterSyncEventTest.php
+++ b/Tests/Unit/Event/AfterSyncEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use PHPUnit\Framework\TestCase;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class AfterSyncEventTest extends TestCase
 {

--- a/Tests/Unit/Event/BeforeSyncEventTest.php
+++ b/Tests/Unit/Event/BeforeSyncEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use PHPUnit\Framework\TestCase;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class BeforeSyncEventTest extends TestCase
 {

--- a/Tests/Unit/Event/ModifyMenuItemsEventTest.php
+++ b/Tests/Unit/Event/ModifyMenuItemsEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -21,7 +21,8 @@ use TYPO3\CMS\Backend\Template\Components\Menu\MenuItem;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class ModifyMenuItemsEventTest extends TestCase
 {

--- a/Tests/Unit/Event/ModifyTableListEventTest.php
+++ b/Tests/Unit/Event/ModifyTableListEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -20,7 +20,8 @@ use PHPUnit\Framework\TestCase;
  *
  * @author  Rico Sonntag <rico.sonntag@netresearch.de>
  * @license Netresearch https://www.netresearch.de
- * @link    https://www.netresearch.de
+ *
+ * @see    https://www.netresearch.de
  */
 final class ModifyTableListEventTest extends TestCase
 {

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
         "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
         "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "ssch/typo3-rector": "^2.0 || ^3.0"
+        "ssch/typo3-rector": "^2.0 || ^3.0",
+        "netresearch/typo3-ci-workflows": "^1.0"
     },
     "extra": {
         "typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -52,14 +52,13 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.65",
-        "saschaegerer/phpstan-typo3": "^1.0 || v2.x-dev",
         "overtrue/phplint": "^9.5",
         "phpstan/phpstan": "^1.0 || ^2.0",
-        "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
         "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
+        "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
         "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "ssch/typo3-rector": "^2.0 || ^3.0",
-        "netresearch/typo3-ci-workflows": "^1.0"
+        "saschaegerer/phpstan-typo3": "^1.0",
+        "ssch/typo3-rector": "^2.0 || ^3.0"
     },
     "extra": {
         "typo3/cms": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,7 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-declare(strict_types=1);
 
 $EM_CONF['nr_sync'] = [
     'title'          => 'Netresearch - TYPO3 synchronization',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,8 +7,6 @@
  * LICENSE file that was distributed with this source code.
  */
 
-declare(strict_types=1);
-
 $EM_CONF['nr_sync'] = [
     'title'          => 'Netresearch - TYPO3 synchronization',
     'description'    => 'A module for synchronizing content from a production system to a single or multiple target systems.',

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -7,6 +7,8 @@
  * LICENSE file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 $EM_CONF['nr_sync'] = [
     'title'          => 'Netresearch - TYPO3 synchronization',
     'description'    => 'A module for synchronizing content from a production system to a single or multiple target systems.',

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,6 @@
 <?php
 
-/**
+/*
  * This file is part of the package netresearch/nr-sync.
  *
  * For the full copyright and license information, please read the
@@ -31,20 +31,20 @@ call_user_func(static function (): void {
             'os'          => '',
             'exec'        => '',
             'className'   => ClearCacheService::class,
-        ]
+        ],
     );
 
     // Add TypoScript automatically (to use it in backend modules)
     ExtensionManagementUtility::addTypoScript(
         'nr_sync',
         'constants',
-        '@import "EXT:nr_sync/Configuration/TypoScript/constants.typoscript"'
+        '@import "EXT:nr_sync/Configuration/TypoScript/constants.typoscript"',
     );
 
     ExtensionManagementUtility::addTypoScript(
         'nr_sync',
         'setup',
-        '@import "EXT:nr_sync/Configuration/TypoScript/setup.typoscript"'
+        '@import "EXT:nr_sync/Configuration/TypoScript/setup.typoscript"',
     );
 
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['scheduler']['tasks'][Task::class] = [


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to immutable commit SHAs (prevents tag/branch force-push attacks)
- Add Dependabot configuration for automatic GitHub Actions version updates

## Context

On 2026-03-19, `aquasecurity/trivy-action` was compromised via a tag force-push attack that exfiltrated secrets from CI runners. SHA-pinning prevents this class of attack entirely.

The netresearch org now enforces `sha_pinning_required=true` — workflows using tag/branch references will fail.

Ref: https://github.com/netresearch/ofelia/issues/535

## Test plan

- [ ] Verify CI passes with SHA-pinned actions
- [ ] Verify Dependabot creates PRs for action updates