### PR TITLE
fix(ci): skip composer audit on ELTS-only TYPO3 v12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    with:
+      # TYPO3 v12.4 is in ELTS; the SA-2026 fixes (12.4.46) ship only via
+      # the paid ELTS repository and are absent from public Packagist, so
+      # `composer audit` can never pass on the free v12 line this extension
+      # targets. Skip it until the extension moves to a maintained branch.
+      skip-composer-audit: true
 
   fuzz:
     uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main


### PR DESCRIPTION
## Problem

This extension targets TYPO3 **`^12.4` only**. As of 2026-06-15, v12.4
is in ELTS: the TYPO3-CORE-SA-2026-007…019 fixes (12.4.46) ship via the
paid ELTS repository and are absent from public Packagist. `composer
audit` therefore reports unfixable advisories against the installed
v12.4.45 and fails on every CI run.

## Fix

Skip the `composer audit` job (`skip-composer-audit: true`) until the
extension moves to a maintained TYPO3 branch (v13.4 / v14.3). The
install-time advisory block is handled centrally in
`typo3-ci-workflows`.
