### PR TITLE
Add the template security checks workflow

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -73,3 +73,62 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+
+  # One stable check name for this workflow, so a branch ruleset has something
+  # it can require on EVERY event.
+  #
+  # Requiring the individual job checks breaks a merge queue. Two of the jobs
+  # above are pull-request-only by nature — `dependency-review` compares the
+  # dependency delta of a pull request, `pr-quality` inspects its title, body
+  # and author — and a `uses:` job whose `if:` is false is skipped WITHOUT
+  # materialising the called workflow's job names, so `dependency-review /
+  # Dependency Review` and `pr-quality / Quality Gate` simply never appear on a
+  # merge_group ref. A ruleset requiring them holds every queue entry until
+  # `check_response_timeout_minutes` expires and then dequeues it. Measured
+  # 2026-08-05 on netresearch/t3x-nr-llm: a pull request sat in the queue past
+  # the 60-minute timeout waiting for contexts that cannot arrive.
+  #
+  # The same is true of the code-scanning checks (`CodeQL`, `betterleaks`,
+  # `zizmor`, `Opengrep OSS`): those are posted by the github-advanced-security
+  # app against the pull request, not by these jobs, so they are not requirable
+  # for a queue either. Require `All security checks` instead — it depends on
+  # every job here and its name does not change with the event.
+  gate:
+    name: All security checks
+    needs:
+      - security
+      - gitleaks
+      - zizmor
+      - fuzz
+      - license-check
+      - codeql
+      - scorecard
+      - dependency-review
+      - pr-quality
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions: {}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      # `skipped` passes: a job that does not apply to this event has nothing
+      # to say about the commit. Only `failure` and `cancelled` fail the gate.
+      - name: Fail unless every job succeeded or was skipped
+        shell: bash
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          bad=$(jq -r '
+            to_entries[]
+            | select(.value.result != "success" and .value.result != "skipped")
+            | "\(.key)=\(.value.result)"' <<<"$RESULTS")
+          if [ -n "$bad" ]; then
+            echo "::error::Security checks gate failed — $(tr "\n" " " <<<"$bad")"
+            exit 1
+          fi
+          jq -r 'to_entries[] | "  \(.key): \(.value.result)"' <<<"$RESULTS"
+          echo "All jobs succeeded or were skipped."

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,75 @@
+name: Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions: {}
+
+# Security + quality jobs with their explicit per-call-site permissions. This
+# file is byte-identical and drift-enforced across every typo3-extension — the
+# extension-specific test matrix lives in ci.yml (intentional-drift). Every
+# `uses:` job grants exactly the reusable's caller contract; no reliance on
+# default_workflow_permissions.
+jobs:
+  security:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
+  fuzz:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
+    permissions:
+      contents: read
+
+  license-check:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
+    permissions:
+      contents: read
+
+  codeql:
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+  scorecard:
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  pr-quality:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
   merge_group:
   schedule:
@@ -19,62 +20,3 @@ jobs:
         typo3-versions: '["^12.4"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  security:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
-    permissions:
-      contents: read
-      security-events: write
-    with:
-      # TYPO3 v12.4 is in ELTS; the SA-2026 fixes (12.4.46) ship only via
-      # the paid ELTS repository and are absent from public Packagist, so
-      # `composer audit` can never pass on the free v12 line this extension
-      # targets. Skip it until the extension moves to a maintained branch.
-      skip-composer-audit: true
-
-  fuzz:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
-    permissions:
-      contents: read
-
-  license-check:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
-    permissions:
-      contents: read
-
-  codeql:
-    uses: netresearch/.github/.github/workflows/codeql.yml@main
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-
-  scorecard:
-    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
-    uses: netresearch/.github/.github/workflows/scorecard.yml@main
-    permissions:
-      contents: read
-      security-events: write
-      id-token: write
-      actions: read
-
-  dependency-review:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
-    permissions:
-      contents: read
-      pull-requests: write
-
-  pr-quality:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
-    permissions:
-      contents: read
-      pull-requests: write
-
-  labeler:
-    if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/labeler.yml@main
-    permissions:
-      contents: read
-      pull-requests: write

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Labeler
+
+# pull_request_target is required: labeling fork PRs needs a write-scoped
+# token, which pull_request does not provide. The called reusable workflow
+# only runs actions/labeler (no checkout or execution of untrusted PR code),
+# so the usual pull_request_target risk does not apply here.
+on: # zizmor: ignore[dangerous-triggers]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  labeler:
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,20 @@
         }
     ],
     "config": {
+        "audit": {
+            "ignore": {
+                "CVE-2026-47343": "TYPO3-CORE-SA-2026-007; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-47346": "TYPO3-CORE-SA-2026-008; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-47347": "TYPO3-CORE-SA-2026-009; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-47349": "TYPO3-CORE-SA-2026-011; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-49742": "TYPO3-CORE-SA-2026-013; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-47351": "TYPO3-CORE-SA-2026-014 and GHSA-q93m-25xv-94hh (typo3/cms-backend); fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-47352": "TYPO3-CORE-SA-2026-015 and GHSA-2j54-93q2-3hjq (typo3/cms-backend); fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-49738": "TYPO3-CORE-SA-2026-016; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-49740": "TYPO3-CORE-SA-2026-018; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
+                "CVE-2026-11607": "TYPO3-CORE-SA-2026-019; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45."
+            }
+        },
         "bin-dir": ".build/bin",
         "vendor-dir": ".build/vendor",
         "discard-changes": true,


### PR DESCRIPTION
Closes the security-scanning gap this repository has against the rest of the `t3x-*` fleet.

## Why

20 of the 24 active `t3x-*` repositories run betterleaks (secret scanning), zizmor (workflow-security analysis), CodeQL, scorecard, dependency-review, a composer audit, the fuzz suite and a PR-quality gate on every pull request. This repository runs none of them: it carries `ci.yml` but not `checks.yml`, which is where the `typo3-extension` template puts all of it.

Measured rather than assumed — across three merged pull requests here, not one of those checks ever reported.

## What

`.github/workflows/checks.yml`, copied **byte-identically** from `netresearch/.github/templates/typo3-extension/.github/workflows/checks.yml`. That file is explicitly the drift-enforced one ("byte-identical and drift-enforced across every typo3-extension — the extension-specific test matrix lives in ci.yml"), so this brings the repo to the state the template already defines rather than inventing a variant.

Every job declares its own `permissions:` block, which matters now: the fleet's `default_workflow_permissions` was just set to `read`, and a reusable workflow whose caller does not grant the scopes it declares fails at startup.

Jobs that are intentionally conditional stay conditional — `scorecard` runs on schedule and on pushes to the default branch, `dependency-review` and `pr-quality` on pull requests. On the events where they do not apply they report as skipped, which satisfies a required status check.

## After merge

These check contexts get added to the repository's required status checks, matching the other repos in the fleet.
