### PR TITLE
Migrate to TYPO3 13.4 and adopt the shared org rector config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     with:
-        php-versions: '["8.1","8.2","8.3"]'
-        typo3-versions: '["^12.4"]'
+        php-versions: '["8.2","8.3","8.4","8.5"]'
+        typo3-versions: '["^13.4"]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1,6 +1,31 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^There is no request attribute \"route\" configured so we can't figure out the exact type to return when calling Psr\\\\Http\\\\Message\\\\ServerRequestInterface\\:\\:getAttribute$#"
+			message: '#^There is no request attribute "route" configured so we can''t figure out the exact type to return when calling Psr\\Http\\Message\\ServerRequestInterface\:\:getAttribute$#'
+			identifier: phpstanTypo3.requestAttributeValidation
 			count: 1
 			path: ../Classes/Controller/BaseSyncModuleController.php
+
+		-
+			message: '''
+				#^Call to method saveAdditionalFields\(\) of deprecated class Netresearch\\NrScheduler\\AbstractAdditionalFieldProvider\:
+				since 2\.0\.0, will be removed together with TYPO3 v14 support\. This class
+				            wraps \\TYPO3\\CMS\\Scheduler\\AbstractAdditionalFieldProvider, which TYPO3
+				            deprecated in v14 and removes in v15\.0\. Migrate consuming tasks to native
+				            task types with additional fields declared via TCA\.$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: ../Classes/Scheduler/SyncImportTask/AdditionalFieldsProvider.php
+
+		-
+			message: '''
+				#^Class Netresearch\\Sync\\Scheduler\\SyncImportTask\\AdditionalFieldsProvider extends deprecated class Netresearch\\NrScheduler\\AbstractAdditionalFieldProvider\:
+				since 2\.0\.0, will be removed together with TYPO3 v14 support\. This class
+				            wraps \\TYPO3\\CMS\\Scheduler\\AbstractAdditionalFieldProvider, which TYPO3
+				            deprecated in v14 and removes in v15\.0\. Migrate consuming tasks to native
+				            task types with additional fields declared via TCA\.$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: ../Classes/Scheduler/SyncImportTask/AdditionalFieldsProvider.php

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -1,7 +1,4 @@
 includes:
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-    - %currentWorkingDirectory%/.build/vendor/saschaegerer/phpstan-typo3/extension.neon
     - %currentWorkingDirectory%/Build/phpstan-baseline.neon
 
 parameters:
@@ -18,3 +15,12 @@ parameters:
         - %currentWorkingDirectory%/ext_emconf.php
 
     treatPhpDocTypesAsCertain: false
+
+    # ergebnis/phpstan-rules is auto-registered by phpstan/extension-installer
+    # (transitively required via netresearch/typo3-ci-workflows). Its default
+    # ruleset (allRules: true) enforces opinionated redesigns (no isset(),
+    # final everywhere, no extends, no nullable/default parameters) that this
+    # extension does not follow yet. Adopting them is a separate hardening
+    # pass; disabled here so the shared-config adoption stays behaviour-neutral.
+    ergebnis:
+        allRules: false

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -46,11 +46,10 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::EARLY_RETURN,
         SetList::INSTANCEOF,
         SetList::PRIVATIZATION,
-        SetList::STRICT_BOOLEANS,
         SetList::TYPE_DECLARATION,
 
         LevelSetList::UP_TO_PHP_81,
-        Typo3LevelSetList::UP_TO_TYPO3_12,
+        Typo3LevelSetList::UP_TO_TYPO3_13,
     ]);
 
     // Skip some rules

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -9,56 +9,23 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\Config\RectorConfig;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector;
-use Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector;
-use Rector\DeadCode\Rector\Property\RemoveUselessVarTagRector;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
-use Rector\Set\ValueObject\LevelSetList;
-use Rector\Set\ValueObject\SetList;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->paths([
-        __DIR__ . '/../Classes',
-        __DIR__ . '/../Configuration',
-        __DIR__ . '/../Resources',
-        __DIR__ . '/../ext_*.php',
-    ]);
+$configure = require_once __DIR__ . '/../.build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
-    $rectorConfig->skip([
-        __DIR__ . '/../ext_emconf.php',
-        __DIR__ . '/../ext_*.sql',
-    ]);
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: paths, code-quality sets, rule skips,
+    // and the package's ergebnis-free phpstan-rector.neon.
+    $configure($rectorConfig, __DIR__ . '/..');
 
-    $rectorConfig->phpstanConfig('Build/phpstan.neon');
-    $rectorConfig->importNames();
-    $rectorConfig->removeUnusedImports();
     $rectorConfig->disableParallel();
 
-    // Define what rule sets will be applied
     $rectorConfig->sets([
-        SetList::CODE_QUALITY,
-        SetList::CODING_STYLE,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::INSTANCEOF,
-        SetList::PRIVATIZATION,
-        SetList::TYPE_DECLARATION,
-
-        LevelSetList::UP_TO_PHP_81,
         Typo3LevelSetList::UP_TO_TYPO3_13,
     ]);
 
-    // Skip some rules
     $rectorConfig->skip([
-        CatchExceptionNameMatchingTypeRector::class,
-        ClassPropertyAssignToConstructorPromotionRector::class,
-        RemoveUselessParamTagRector::class,
-        RemoveUselessReturnTagRector::class,
-        RemoveUselessVarTagRector::class,
-        RemoveUnusedPrivateMethodParameterRector::class,
+        __DIR__ . '/../ext_*.sql',
     ]);
 };

--- a/Classes/Command/ClearCache.php
+++ b/Classes/Command/ClearCache.php
@@ -159,7 +159,10 @@ class ClearCache extends Command
             $result[] = explode(',', trim($fileLine));
         }
 
-        return array_filter(array_merge(...$result));
+        return array_filter(
+            array_merge(...$result),
+            static fn (string $entry): bool => $entry !== '',
+        );
     }
 
     /**

--- a/Classes/Controller/BaseSyncModuleController.php
+++ b/Classes/Controller/BaseSyncModuleController.php
@@ -42,8 +42,8 @@ use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Resource\Exception\ExistingTargetFolderException;
 use TYPO3\CMS\Core\Resource\Exception\InsufficientFolderAccessPermissionsException;
@@ -132,7 +132,7 @@ class BaseSyncModuleController implements ModuleInterface
     protected ?Area $area = null;
 
     /**
-     * @var Urls;
+     * @var Urls
      */
     private Urls $urlGenerator;
 
@@ -447,7 +447,7 @@ class BaseSyncModuleController implements ModuleInterface
                 ->setIcon(
                     $this->iconFactory->getIcon(
                         'actions-lock',
-                        Icon::SIZE_SMALL,
+                        IconSize::SMALL,
                     ),
                 )
                 ->setClasses('custom-btn-danger');
@@ -467,7 +467,7 @@ class BaseSyncModuleController implements ModuleInterface
                 ->setIcon(
                     $this->iconFactory->getIcon(
                         'actions-unlock',
-                        Icon::SIZE_SMALL,
+                        IconSize::SMALL,
                     ),
                 );
         }
@@ -492,9 +492,9 @@ class BaseSyncModuleController implements ModuleInterface
     }
 
     /**
-     * @param ModuleTemplate $moduleTemplate
-     * @param string         $systemName
-     * @param string[]       $system
+     * @param ModuleTemplate                                                                                               $moduleTemplate
+     * @param string                                                                                                       $systemName
+     * @param array{name: string, directory: string, url-path: string, notify: array<string, string|string[]>, hide: bool} $system
      *
      * @throws RouteNotFoundException
      */
@@ -520,7 +520,7 @@ class BaseSyncModuleController implements ModuleInterface
                 ->setIcon(
                     $this->iconFactory->getIcon(
                         'actions-lock',
-                        Icon::SIZE_SMALL,
+                        IconSize::SMALL,
                     ),
                 )
                 ->setClasses('custom-btn-danger');
@@ -540,7 +540,7 @@ class BaseSyncModuleController implements ModuleInterface
                 ->setIcon(
                     $this->iconFactory->getIcon(
                         'actions-unlock',
-                        Icon::SIZE_SMALL,
+                        IconSize::SMALL,
                     ),
                 );
         }
@@ -722,9 +722,6 @@ class BaseSyncModuleController implements ModuleInterface
         return $tableEvent->getTables();
     }
 
-    /**
-     * @return string|null
-     */
     public function getDumpFile(): ?string
     {
         return $this->moduleData->get('dumpFile');
@@ -779,7 +776,7 @@ class BaseSyncModuleController implements ModuleInterface
     }
 
     /**
-     * @param array<string, array<string, string>> $parameters An array of parameters
+     * @param array<string, int|string|array<string, string>> $parameters An array of parameters
      *
      * @return string
      *

--- a/Classes/Controller/TableStateSyncModuleController.php
+++ b/Classes/Controller/TableStateSyncModuleController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Netresearch\Sync\Controller;
 
+use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Netresearch\Sync\Helper\Area;
 use Netresearch\Sync\Traits\FlashMessageTrait;
 use Netresearch\Sync\Traits\TableDifferenceTrait;
@@ -56,10 +57,15 @@ class TableStateSyncModuleController extends BaseSyncModuleController
      */
     private function getAllTables(): array
     {
-        return $this->connectionPool
+        $tableNames = $this->connectionPool
             ->getConnectionForTable('pages')
             ->createSchemaManager()
-            ->listTableNames();
+            ->introspectTableNames();
+
+        return array_map(
+            static fn (OptionallyQualifiedName $tableName): string => $tableName->toString(),
+            $tableNames,
+        );
     }
 
     /**
@@ -74,11 +80,11 @@ class TableStateSyncModuleController extends BaseSyncModuleController
             $columns = $this->connectionPool
                 ->getConnectionForTable($tableName)
                 ->createSchemaManager()
-                ->listTableColumns($tableName);
+                ->introspectTableColumnsByUnquotedName($tableName);
 
             $columnNames = [];
             foreach ($columns as $column) {
-                $columnNames[] = $column->getName();
+                $columnNames[] = $column->getObjectName()->toString();
             }
 
             $tables[$tableName] = $columnNames;

--- a/Classes/Event/AfterSyncEvent.php
+++ b/Classes/Event/AfterSyncEvent.php
@@ -20,7 +20,7 @@ namespace Netresearch\Sync\Event;
  *
  * @see    https://www.netresearch.de
  */
-final class AfterSyncEvent
+final readonly class AfterSyncEvent
 {
     /**
      * Constructor.
@@ -31,10 +31,10 @@ final class AfterSyncEvent
      * @param bool               $success
      */
     public function __construct(
-        private readonly array $tables,
-        private readonly string $dumpFile,
-        private readonly ?string $targetName,
-        private readonly bool $success,
+        private array $tables,
+        private string $dumpFile,
+        private ?string $targetName,
+        private bool $success,
     ) {}
 
     /**

--- a/Classes/Event/AfterSyncEvent.php
+++ b/Classes/Event/AfterSyncEvent.php
@@ -53,9 +53,6 @@ final class AfterSyncEvent
         return $this->dumpFile;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTargetName(): ?string
     {
         return $this->targetName;

--- a/Classes/Event/BeforeSyncEvent.php
+++ b/Classes/Event/BeforeSyncEvent.php
@@ -61,9 +61,6 @@ final class BeforeSyncEvent
         return $this->dumpFile;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTargetName(): ?string
     {
         return $this->targetName;

--- a/Classes/Event/FalSyncEvent.php
+++ b/Classes/Event/FalSyncEvent.php
@@ -19,7 +19,7 @@ namespace Netresearch\Sync\Event;
  *
  * @see    https://www.netresearch.de
  */
-final class FalSyncEvent
+final readonly class FalSyncEvent
 {
     /**
      * Constructor.
@@ -28,8 +28,8 @@ final class FalSyncEvent
      * @param string $dumpFilePrefix
      */
     public function __construct(
-        private readonly int $areaId,
-        private readonly string $dumpFilePrefix,
+        private int $areaId,
+        private string $dumpFilePrefix,
     ) {}
 
     /**

--- a/Classes/Generator/Urls.php
+++ b/Classes/Generator/Urls.php
@@ -17,7 +17,6 @@ use Netresearch\Sync\Controller\BaseSyncModuleController;
 use Netresearch\Sync\Helper\Area;
 use Netresearch\Sync\Service\StorageService;
 use Netresearch\Sync\Traits\TranslationTrait;
-use TYPO3\CMS\Core\Resource\FileInterface;
 
 /**
  * Generate files with the list of URLs that have to be called
@@ -171,12 +170,11 @@ class Urls
                 ->getSyncFolder()
                 ->getSubfolder($folder);
 
-            /** @var FileInterface|null $file */
             $file = $this->storageService
                 ->getDefaultStorage()
                 ->createFile($fileName, $folder);
 
-            $file?->setContents($content);
+            $file->setContents($content);
         }
 
         return count($folders);

--- a/Classes/ModuleInterface.php
+++ b/Classes/ModuleInterface.php
@@ -39,8 +39,6 @@ interface ModuleInterface
 
     /**
      * Returns the name of the synchronization file containing the SQL statements to update the database records.
-     *
-     * @return string|null
      */
     public function getDumpFile(): ?string;
 

--- a/Classes/SyncList.php
+++ b/Classes/SyncList.php
@@ -246,7 +246,10 @@ class SyncList
             }
         }
 
-        $pageIds = array_filter(array_merge(...$pageIds));
+        $pageIds = array_filter(
+            array_merge(...$pageIds),
+            static fn (int $pageId): bool => $pageId !== 0,
+        );
         $pageIds = array_merge($pageIds, $this->getPageTranslations($pageIds));
 
         return array_unique($pageIds);
@@ -432,7 +435,7 @@ class SyncList
             // See if there is a page on the branch (may be missing due to editing rights)
             if (isset($value['page'])) {
                 $pageIds[] = [
-                    $value['page']['uid'],
+                    (int) $value['page']['uid'],
                 ];
             }
 
@@ -442,7 +445,10 @@ class SyncList
             }
         }
 
-        return array_filter(array_merge(...$pageIds));
+        return array_filter(
+            array_merge(...$pageIds),
+            static fn (int $pageId): bool => $pageId !== 0,
+        );
     }
 
     /**

--- a/Classes/Table.php
+++ b/Classes/Table.php
@@ -18,6 +18,7 @@ use function in_array;
 use Netresearch\Sync\Service\StorageService;
 use Netresearch\Sync\Traits\FlashMessageTrait;
 use Netresearch\Sync\Traits\TranslationTrait;
+use RuntimeException;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -248,6 +249,7 @@ class Table
      * @return bool
      *
      * @throws Exception
+     * @throws RuntimeException
      */
     protected function hasUpdatedRows(): bool
     {
@@ -258,7 +260,7 @@ class Table
         $strWhere = $this->getDumpWhereCondition();
 
         if ($strWhere === '' || $strWhere === false) {
-            throw new Exception(
+            throw new RuntimeException(
                 'Could not get WHERE condition for tstamp field for table "'
                 . $this->tableName . '".',
             );
@@ -315,7 +317,10 @@ class Table
         $list   = [];
 
         if (isset($result['0']['uid_list']) && ($result['0']['uid_list'] !== '')) {
-            $list = array_filter(explode(',', (string) $result['0']['uid_list']));
+            $list = array_filter(
+                explode(',', (string) $result['0']['uid_list']),
+                static fn (string $uid): bool => $uid !== '',
+            );
         }
 
         $data = [];
@@ -376,6 +381,7 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
      * Uses REPLACE instead of INSERT.
      *
      * @throws Exception
+     * @throws RuntimeException
      */
     protected function appendUpdateToFile(): void
     {
@@ -386,7 +392,7 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
         $strWhere = $this->getDumpWhereCondition();
 
         if ($strWhere === '' || $strWhere === false) {
-            throw new Exception(
+            throw new RuntimeException(
                 'Could not get WHERE condition for tstamp field for table "'
                 . $this->tableName . '".',
             );
@@ -453,8 +459,6 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
 
     /**
      * Returns table tstamp field - if defined, otherwise false.
-     *
-     * @return string|false
      */
     protected function getTstampField(): false|string
     {
@@ -557,11 +561,11 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
                 . ' ON DUPLICATE KEY UPDATE cruser_id = %s, %s = %s',
                 $strUpdateField,
                 $connection->quote($this->tableName),
-                $connection->quote($nTime),
-                $connection->quote($nUserId),
-                $connection->quote($nUserId),
+                $connection->quote((string) $nTime),
+                $connection->quote((string) $nUserId),
+                $connection->quote((string) $nUserId),
                 $strUpdateField,
-                $connection->quote($nTime),
+                $connection->quote((string) $nTime),
             ),
         );
     }
@@ -569,8 +573,6 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
     /**
      * Return a sql statement to drop rows from the table which are useless
      * in context of there control fields (hidden,deleted,endtime).
-     *
-     * @return string|null
      */
     public function getSqlDroppingObsoleteRows(): ?string
     {
@@ -589,7 +591,7 @@ TRUNCATE TABLE ' . $this->tableName . ";\n\n");
         );
 
         $strStatement = 'DELETE FROM '
-            . $connection->quoteIdentifier($this->tableName);
+            . $connection->quoteSingleIdentifier($this->tableName);
         $arWhereClauseParts = [];
         if (isset($arControlFields['delete'])) {
             $arWhereClauseParts[] = $arControlFields['delete'] . ' = 1';

--- a/Classes/Traits/DumpFileTrait.php
+++ b/Classes/Traits/DumpFileTrait.php
@@ -251,7 +251,7 @@ trait DumpFileTrait
      *
      * @return void
      *
-     * @throws Exception If file can't be zipped
+     * @throws RuntimeException If file can't be zipped
      */
     private function finalizeDumpFile(string $dumpFileName, array $directories): void
     {
@@ -262,7 +262,7 @@ trait DumpFileTrait
         $dumpFile = $this->createGZipFile($tempFolder, $dumpFileName);
 
         if ($dumpFile === null) {
-            throw new Exception('Could not create ZIP file.');
+            throw new RuntimeException('Could not create ZIP file.');
         }
 
         // Copy files to correct location
@@ -437,8 +437,6 @@ trait DumpFileTrait
      *
      * @param Folder $folder   Folder where the file si stored
      * @param string $filename Name of File
-     *
-     * @return FileInterface|null
      */
     protected function createGZipFile(Folder $folder, string $filename): ?FileInterface
     {
@@ -448,7 +446,6 @@ trait DumpFileTrait
             $tempFileIdentifier = $folder->getIdentifier() . $filename;
             $dumpFile           = $tempStorage->getFile($tempFileIdentifier);
 
-            /** @var FileInterface|null $compressedDumpFile */
             $compressedDumpFile = $tempStorage->createFile($filename . '.gz', $folder);
             $compressedDumpFile?->setContents(
                 gzencode(
@@ -518,7 +515,7 @@ trait DumpFileTrait
      *
      * @return FileInterface
      *
-     * @throws Exception
+     * @throws RuntimeException
      */
     private function openTempDumpFile(string $filename, array $directories): FileInterface
     {
@@ -529,7 +526,7 @@ trait DumpFileTrait
         if ($tempStorage->hasFile($tempFileIdentifier)
             || $tempStorage->hasFile($tempFileIdentifier . '.gz')
         ) {
-            throw new Exception(
+            throw new RuntimeException(
                 $this->getLabel('error.last_sync_not_finished')
                 . "<br/>\n"
                 . $tempFileIdentifier . '(.gz)',
@@ -544,7 +541,7 @@ trait DumpFileTrait
             if ($defaultStorage->hasFile($fileIdentifier)
                 || $defaultStorage->hasFile($fileIdentifier . '.gz')
             ) {
-                throw new Exception(
+                throw new RuntimeException(
                     $this->getLabel('error.last_sync_not_finished'),
                 );
             }
@@ -580,6 +577,7 @@ trait DumpFileTrait
      * @return void
      *
      * @throws Exception
+     * @throws RuntimeException
      */
     protected function dumpTableByPageIDs(
         array $pageIDs,
@@ -588,7 +586,7 @@ trait DumpFileTrait
         bool $contentIDs = false,
     ): void {
         if (str_ends_with($tableName, '_mm')) {
-            throw new Exception(
+            throw new RuntimeException(
                 $this->getLabel(
                     'error.mm_tables',
                     [
@@ -608,11 +606,11 @@ trait DumpFileTrait
 
         $columns = $connection
             ->createSchemaManager()
-            ->listTableColumns($tableName);
+            ->introspectTableColumnsByUnquotedName($tableName);
 
         $columnNames = [];
         foreach ($columns as $column) {
-            $columnNames[] = $column->getName();
+            $columnNames[] = $column->getObjectName()->toString();
         }
 
         $queryBuilder = $this->getQueryBuilderForTable($tableName);
@@ -725,7 +723,7 @@ trait DumpFileTrait
 
         return sprintf(
             'DELETE FROM %s WHERE uid = %d;',
-            $connection->quoteIdentifier($tableName),
+            $connection->quoteSingleIdentifier($tableName),
             $uid,
         );
     }
@@ -752,14 +750,14 @@ trait DumpFileTrait
             // TYPO-2215 - Match the column to its update value
             $updateParts[$key] = sprintf(
                 '%1$s = VALUES(%1$s)',
-                $connection->quoteIdentifier($key),
+                $connection->quoteSingleIdentifier($key),
             );
         }
 
         return sprintf(
             'INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s;',
-            $connection->quoteIdentifier($tableName),
-            implode(', ', $connection->quoteIdentifiers($columnNames)),
+            $connection->quoteSingleIdentifier($tableName),
+            implode(', ', array_map($connection->quoteSingleIdentifier(...), $columnNames)),
             implode(', ', $row),
             implode(', ', $updateParts),
         );
@@ -786,11 +784,11 @@ trait DumpFileTrait
             $columns = $this->connectionPool
                 ->getConnectionForTable($mmTableName)
                 ->createSchemaManager()
-                ->listTableColumns($mmTableName);
+                ->introspectTableColumnsByUnquotedName($mmTableName);
 
             $columnNames = [];
             foreach ($columns as $column) {
-                $columnNames[] = $column->getName();
+                $columnNames[] = $column->getObjectName()->toString();
             }
 
             foreach ($arTableFields as $arMMConfig) {
@@ -927,8 +925,8 @@ trait DumpFileTrait
         // SQL-dump path: build a literal WHERE clause for inclusion in the
         // generated .sql file. Must be a string because the dump is replayed
         // verbatim against the target DB (not via a QueryBuilder). All
-        // values pass through quoteIdentifier()/quote() with the int cast.
-        $strWhere = $connection->quoteIdentifier($strFieldName) . ' = ' . $uid;
+        // values pass through quoteSingleIdentifier()/quote() with the int cast.
+        $strWhere = $connection->quoteSingleIdentifier($strFieldName) . ' = ' . $uid;
 
         if (isset($arMMConfig['MM_match_fields'])) {
             foreach ($arMMConfig['MM_match_fields'] as $strName => $strValue) {
@@ -936,7 +934,7 @@ trait DumpFileTrait
                     $strName,
                     $queryBuilder->createNamedParameter($strValue),
                 ));
-                $strWhere .= ' AND ' . $connection->quoteIdentifier($strName) . ' = ' . $connection->quote($strValue);
+                $strWhere .= ' AND ' . $connection->quoteSingleIdentifier($strName) . ' = ' . $connection->quote($strValue);
             }
         }
 
@@ -945,7 +943,7 @@ trait DumpFileTrait
         if ($tableName !== 'sys_file_reference') {
             $deleteLines[$tableName][$uid] = sprintf(
                 'DELETE FROM %s WHERE %s;',
-                $connection->quoteIdentifier($tableName),
+                $connection->quoteSingleIdentifier($tableName),
                 $strWhere,
             );
         }
@@ -1321,12 +1319,12 @@ trait DumpFileTrait
                 . ' ON DUPLICATE KEY UPDATE cruser_id = %s, %s = %s',
                 $updateField,
                 $connection->quote($table),
-                $connection->quote($time),
-                $connection->quote($userId),
-                $connection->quote($uid),
-                $connection->quote($userId),
+                $connection->quote((string) $time),
+                $connection->quote((string) $userId),
+                $connection->quote((string) $uid),
+                $connection->quote((string) $userId),
                 $updateField,
-                $connection->quote($time),
+                $connection->quote((string) $time),
             ),
         );
     }

--- a/Classes/Traits/SyncTargetLockTrait.php
+++ b/Classes/Traits/SyncTargetLockTrait.php
@@ -41,7 +41,7 @@ trait SyncTargetLockTrait
                 ->getSyncFolder()
                 ->getSubfolder($system['directory']);
 
-            if ($lockState) {
+            if ((bool) $lockState) {
                 $systemDirectory
                     ->getStorage()
                     ->createFile('.lock', $systemDirectory)

--- a/Classes/Traits/TableDifferenceTrait.php
+++ b/Classes/Traits/TableDifferenceTrait.php
@@ -88,11 +88,11 @@ trait TableDifferenceTrait
         $columns = $this->connectionPool
             ->getConnectionForTable($tableName)
             ->createSchemaManager()
-            ->listTableColumns($tableName);
+            ->introspectTableColumnsByUnquotedName($tableName);
 
         $columnNames = [];
         foreach ($columns as $column) {
-            $columnNames[] = $column->getName();
+            $columnNames[] = $column->getObjectName()->toString();
         }
 
         // Table still doesn't exist

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -35,7 +35,7 @@ $backendModulesConfiguration = [
         'labels'                                   => 'LLL:EXT:nr_sync/Resources/Private/Language/locallang_mod_sync.xlf',
         'extensionName'                            => 'NrSync',
         'inheritNavigationComponentFromMainModule' => false,
-        'navigationComponent'                      => '@typo3/backend/page-tree/page-tree-element',
+        'navigationComponent'                      => '@typo3/backend/tree/page-tree-element',
     ],
     'netresearch_sync_singlePage' => [
         'parent'         => 'netresearch_sync',

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,13 @@
             "git.netresearch.de"
         ],
         "allow-plugins": {
-            "typo3/cms-composer-installers": true,
-            "typo3/class-alias-loader": true
+            "a9f/fractor-extension-installer": true,
+            "captainhook/hook-installer": true,
+            "dg/bypass-finals": true,
+            "infection/extension-installer": true,
+            "phpstan/extension-installer": true,
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
         }
     },
     "minimum-stability": "dev",
@@ -51,14 +56,7 @@
         "netresearch/nr-scheduler": "*"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.65",
-        "overtrue/phplint": "^9.5",
-        "phpstan/phpstan": "^1.0 || ^2.0",
-        "phpstan/phpstan-deprecation-rules": "^1.0 || ^2.0",
-        "phpstan/phpstan-strict-rules": "^1.0 || ^2.0",
-        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "saschaegerer/phpstan-typo3": "^1.0 || ^3.0",
-        "ssch/typo3-rector": "^2.0 || ^3.0"
+        "netresearch/typo3-ci-workflows": "^1.1"
     },
     "extra": {
         "typo3/cms": {

--- a/composer.json
+++ b/composer.json
@@ -25,20 +25,6 @@
         }
     ],
     "config": {
-        "audit": {
-            "ignore": {
-                "CVE-2026-47343": "TYPO3-CORE-SA-2026-007; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-47346": "TYPO3-CORE-SA-2026-008; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-47347": "TYPO3-CORE-SA-2026-009; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-47349": "TYPO3-CORE-SA-2026-011; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-49742": "TYPO3-CORE-SA-2026-013; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-47351": "TYPO3-CORE-SA-2026-014 and GHSA-q93m-25xv-94hh (typo3/cms-backend); fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-47352": "TYPO3-CORE-SA-2026-015 and GHSA-2j54-93q2-3hjq (typo3/cms-backend); fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-49738": "TYPO3-CORE-SA-2026-016; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-49740": "TYPO3-CORE-SA-2026-018; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45.",
-                "CVE-2026-11607": "TYPO3-CORE-SA-2026-019; fixed in 12.4.46, which ships only via the paid ELTS repository. The public v12.4 line ends at 12.4.45."
-            }
-        },
         "bin-dir": ".build/bin",
         "vendor-dir": ".build/vendor",
         "discard-changes": true,
@@ -58,10 +44,10 @@
     "require": {
         "ext-ftp": "*",
         "ext-zlib": "*",
-        "typo3/cms-core": "^12.4",
-        "typo3/cms-backend": "^12.4",
-        "typo3/cms-extbase": "^12.4",
-        "typo3/cms-fluid": "^12.4",
+        "typo3/cms-core": "^13.4",
+        "typo3/cms-backend": "^13.4",
+        "typo3/cms-extbase": "^13.4",
+        "typo3/cms-fluid": "^13.4",
         "netresearch/nr-scheduler": "*"
     },
     "require-dev": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,7 +19,7 @@ $EM_CONF['nr_sync'] = [
     'version'        => '1.0.7',
     'constraints'    => [
         'depends' => [
-            'typo3' => '12.4.0-12.99.99',
+            'typo3' => '13.4.0-13.4.99',
         ],
         'conflicts' => [
         ],


### PR DESCRIPTION
Fixes #46.

Two commits, in the order the ticket prescribes: first the TYPO3 ^13.4 migration, then the shared-org-rector-config conversion that was blocked on it.

**Commit 1 — `feat: migrate to TYPO3 13.4`**: raises `typo3/cms-*` to `^13.4` (cold install resolves cms-core 13.4.33, `netresearch/nr-scheduler` 2.0.0), `ext_emconf` to `13.4.0-13.4.99`, and the CI matrix to PHP 8.2–8.5 × `^13.4`. The v12-ELTS `config.audit.ignore` block is removed — the public 13.4 line ships the SA-2026 fixes and `composer audit` passes clean again. Code migration: `IconSize` enum, moved page-tree navigation component, and the Doctrine DBAL 4 breaks (`Exception` is now an interface → `RuntimeException`, `quote()` takes strings only, `quoteIdentifier()` → `quoteSingleIdentifier()`, `listTableNames()`/`listTableColumns()`/`Column::getName()` → the `introspect*`/`getObjectName()->toString()` API). `Typo3LevelSetList::UP_TO_TYPO3_13` was applied and comes back clean on a dry-run. The only two remaining PHPStan findings are baselined with rationale: `AdditionalFieldsProvider` extends nr-scheduler's deprecated `AbstractAdditionalFieldProvider`, which is that package's intended v13/v14 compatibility path; migrating to native task types with TCA-declared fields is follow-up work.

**Commit 2 — `refactor: adopt the shared org rector config`**: `Build/rector.php` becomes the thin wrapper over `netresearch/typo3-ci-workflows` `config/rector/rector.php` (reference pattern: [t3x-nr-textdb](https://github.com/netresearch/t3x-nr-textdb/blob/main/Build/rector.php)), `require-dev` collapses to the meta-package, and `Build/phpstan.neon` drops the manual extension includes now that `phpstan/extension-installer` registers them. The auto-registered `ergebnis/phpstan-rules` opinion ruleset is disabled (`allRules: false`) with a comment — it raised 146 findings (noIsset, final, noExtends, nullable parameters) whose adoption is a separate hardening pass, not part of this conversion. No `remove-dev-deps` guard is needed: unlike the old `^12.4` matrix, every remaining cell resolves the meta-package.

**Verification (local, PHP 8.5)**: `composer validate` ✓, cold install ✓, `composer audit` ✓ (no advisories), `phplint` ✓, CGL dry-run ✓, rector dry-run ✓ (no pending changes under the shared config), PHPStan `--memory-limit=1G` ✓ (0 errors), unit suite ✓ (21 tests, 54 assertions). The repo has no functional suite; the CI matrix is the cross-version gate.
