### PR TITLE
Sync checks.yml so CodeQL analyses this repository's languages

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,13 @@ permissions: {}
 # extension-specific test matrix lives in ci.yml (intentional-drift). Every
 # `uses:` job grants exactly the reusable's caller contract; no reliance on
 # default_workflow_permissions.
+#
+# ANY JOB ADDED BELOW MUST ALSO BE ADDED TO `gate.needs`. The gate is the only
+# context a ruleset requires, so a job missing from that list is a job whose
+# failure cannot block a merge — the coverage loss is silent, and nothing in CI
+# catches it. GitHub Actions does not support YAML anchors in workflow files,
+# so the list cannot be shared with the job definitions; it has to be kept in
+# step by hand.
 jobs:
   security:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
@@ -44,12 +51,20 @@ jobs:
     permissions:
       contents: read
 
+  # `auto` rather than the `actions` default: a TYPO3 extension that ships
+  # JavaScript had none of it analysed, because the default scans workflows
+  # only and GitHub disables code-scanning default setup — which did cover
+  # javascript-typescript — as soon as an advanced configuration uploads its
+  # first SARIF. Merging this file is what triggers that handover, so the
+  # narrow default silently removed a control that had been in place.
   codeql:
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write
       actions: read
+    with:
+      languages: auto
 
   scorecard:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
@@ -111,7 +126,7 @@ jobs:
     permissions: {}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
           egress-policy: audit
 


### PR DESCRIPTION
Last of the 24 `t3x-*` repositories to reach the current org template. Twenty are already on it.

## What this fixes

The template now passes `languages: auto` to the CodeQL reusable. Without it the call takes the input's default `actions` and scans **workflow files only** — and because GitHub disables code-scanning *default setup* the moment an advanced configuration uploads its first SARIF, rolling out the previous revision of this file silently switched off the JavaScript analysis that default setup had been performing.

`auto` detects rather than assumes: `actions` always, `go` on a `go.mod` or any `.go` file, `javascript-typescript` on a `package.json` or any JS/TS source. A PHP-only repository therefore gets `actions` alone and no pointless empty pass.

## This is not theoretical

Re-enabling the analysis across the fleet tonight immediately surfaced findings that had been invisible while JavaScript went unscanned:

| repository | severity | rule | location |
|---|---|---|---|
| `t3x-contexts` | **HIGH** | `js/clear-text-logging` | `Build/playwright/tests/playwright/helper/login.setup.ts:116` and `:126` |
| `t3x-cowriter` | MEDIUM | `js/xss-through-exception` | `Resources/Public/JavaScript/Ckeditor/CowriterDialog.js:941` |

Those are pre-existing defects, not new ones — they were simply unreportable.

## Scope

One file, `.github/workflows/checks.yml`, byte-identical to `netresearch/.github/templates/typo3-extension/.github/workflows/checks.yml` (blob `787510c1`), verified with `cmp`. The drift check enforces that byte-identity, so no per-repository variation is possible here.
