### PR TITLE
feat(agents): add AGENTS.md agent documentation and agent-harness verification

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,93 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — workflows
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+GitHub Actions workflows of this repo. Every workflow is a **thin caller** of centrally maintained reusable workflows in `netresearch/typo3-ci-workflows` and `netresearch/.github` — action pinning, harden-runner, and job internals are maintained there, not here.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Key Files
+| File | Purpose |
+|------|---------|
+| `ci.yml` | Test matrix (PHP 8.2-8.5 × TYPO3 ^13.4) via `typo3-ci-workflows/ci.yml` |
+| `checks.yml` | Security/quality jobs (CodeQL, gitleaks, zizmor, …) with a `gate` job; byte-identical across t3x repos |
+| `harness-verify.yml` | Agent-harness consistency check via `netresearch/.github` `script-check.yml` |
+| `release.yml` | Release via `typo3-ci-workflows/release-typo3-extension.yml` |
+| `republish.yml` | Republish via `typo3-ci-workflows/republish.yml` |
+| `auto-merge-deps.yml` | Auto-merge dependency PRs (`netresearch/.github`) |
+| `community.yml` | stale/lock/greetings (`netresearch/.github`) |
+| `labeler.yml` | PR labeling (`netresearch/.github`, config `../labeler.yml`) |
+<!-- AGENTS-GENERATED:END filemap -->
+
+<!-- AGENTS-GENERATED:START structure -->
+## Workflow files
+```
+.github/
+  dependabot.yml   → dependency update config
+  labeler.yml      → labeler rules
+  workflows/       → thin callers of reusable workflows (see table above)
+```
+There are no composite actions, no CODEOWNERS, and no repo-local PR template (org-level via netresearch/.github).
+<!-- AGENTS-GENERATED:END structure -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Workflow conventions
+- Top-level `permissions: {}`; each `uses:` job grants exactly the reusable's caller contract (e.g. `contents: read`)
+- Reference reusables `@main` — central repos control their own pinning; do not pin reusable refs here
+- `checks.yml` is drift-enforced: any job added there **must** also be added to `gate.needs` (see the comment block in the file)
+- The extension-specific CI matrix lives only in `ci.yml` (intentional drift); everything else stays byte-identical with sibling t3x repos
+- Never use `secrets: inherit` — pass secrets explicitly (`CODECOV_TOKEN` in `ci.yml`)
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START patterns -->
+## Common patterns
+
+### Thin caller of a reusable workflow (the only job shape used here)
+```yaml
+permissions: {}
+
+jobs:
+  ci:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
+    permissions:
+      contents: read
+    with:
+        php-versions: '["8.2","8.3","8.4","8.5"]'
+        typo3-versions: '["^13.4"]'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+```
+Change matrix values in `with:`; never inline job steps into this repo when a central reusable exists.
+<!-- AGENTS-GENERATED:END patterns -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security & safety
+- Required checks come from repo rulesets: `All security checks`, `CodeQL`, `Opengrep OSS`, `ci / All CI checks`, `scorecard`
+- A job missing from `gate.needs` in `checks.yml` silently loses merge-blocking power — keep the list in sync by hand
+- Never expose secrets in logs; never widen a job's `permissions` beyond the reusable's documented contract
+- Workflow-file changes require a PR (push to `master` is ruleset-protected)
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR/commit checklist
+- [ ] Job added to `checks.yml` is also listed in `gate.needs`
+- [ ] `permissions:` blocks unchanged or minimally extended per reusable contract
+- [ ] No `secrets: inherit`
+- [ ] Workflow syntax valid (`zizmor`/actionlint run in CI)
+- [ ] Matrix values still match supported PHP/TYPO3 versions in the repo-root `composer.json`
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real workflows in this directory over generic examples.**
+> `ci.yml` and `checks.yml` demonstrate the caller pattern and the gate convention.
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- Reusable workflow sources: https://github.com/netresearch/typo3-ci-workflows and https://github.com/netresearch/.github
+- GitHub Actions reusable workflow docs: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+- Check sibling t3x repos for the byte-identical `checks.yml` reference
+<!-- AGENTS-GENERATED:END help -->

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,23 @@
+name: Harness Verification
+
+# Verifies agent-harness consistency (AGENTS.md line budget, dead references,
+# documented commands vs composer.json/Makefile, docs/ structure) via
+# scripts/verify-harness.sh. Thin caller of the shared script-check
+# reusable, so the checkout pin and harden-runner are maintained centrally.
+# Exit 2 means warnings only and passes; exit 1 (errors) fails the check.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness-verify:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash scripts/verify-harness.sh || [ $? -eq 2 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,139 @@
+<!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
+
+# AGENTS.md
+
+**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. Root holds global defaults only.
+
+netresearch/nr-sync — TYPO3 v13.4 backend extension (key `nr_sync`) that synchronizes content from a production system to one or more target systems. Extension version: see `ext_emconf.php`. Component map: `docs/ARCHITECTURE.md`.
+
+## Commands (verified against composer.json / Makefile)
+
+<!-- AGENTS-GENERATED:START commands -->
+| Task | Command |
+|------|---------|
+| PHP lint | `composer ci:test:php:lint` |
+| Static analysis | `composer ci:test:php:phpstan` (= `make phpstan`) |
+| Code style check | `composer ci:test:php:cgl` (= `make cgl`) |
+| Code style fix | `composer ci:cgl` (= `make cgl-fix`) |
+| Rector dry-run | `composer ci:test:php:rector` (= `make rector`) |
+| Unit tests | `composer ci:test:php:unit` (= `make test-unit`) |
+| All checks | `composer ci:test` |
+| Harness check | `bash scripts/verify-harness.sh` |
+<!-- AGENTS-GENERATED:END commands -->
+
+> Tool binaries land in `.build/bin/` (composer `bin-dir`); tool configs live in `Build/`. If commands fail, verify against `composer.json` / `Makefile` and update this table.
+
+## Response Style
+- Answer first, elaborate only if needed. No sycophantic openers ("Great question!", "Absolutely!").
+- For yes/no or status questions, lead with the answer.
+- Skip preamble. Match response length to task complexity.
+
+## Workflow
+1. **Before coding**: Read nearest `AGENTS.md` + check Golden Samples for the area you're touching
+2. **After each change**: Run the smallest relevant check (lint → phpstan → single test)
+3. **Before committing**: Run `composer ci:test` if changes affect >2 files or touch shared code
+4. **Before claiming done**: Run verification and **show output as evidence** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output in the same turn
+
+## File Map
+<!-- AGENTS-GENERATED:START filemap -->
+```
+Classes/         → PHP classes (PSR-4: Netresearch\Sync\)
+Configuration/   → backend module registration, Services.yaml, TypoScript, icons
+Resources/       → Fluid templates/partials, XLIFF translations, CSS, icons
+Tests/           → PHPUnit unit tests (Tests/Unit/ only, no functional suite)
+Build/           → tool configs (phpstan, rector, php-cs-fixer, phplint, phpunit)
+Documentation/   → images for README (no RST docs)
+scripts/         → repo scripts (clean-lock.sh, verify-harness.sh)
+docs/            → agent-facing docs (ARCHITECTURE.md, exec-plans/)
+```
+<!-- AGENTS-GENERATED:END filemap -->
+
+## Golden Samples (follow these patterns)
+<!-- AGENTS-GENERATED:START golden-samples -->
+| For | Reference | Key patterns |
+|-----|-----------|--------------|
+| Controller | `Classes/Controller/AssetSyncModuleController.php` | backend sync module controller |
+| Service | `Classes/Service/StorageService.php` | DI service via `Configuration/Services.yaml` |
+| Event | `Classes/Event/BeforeSyncEvent.php` | PSR-14 event |
+| Test | `Tests/Unit/Event/ModifyMenuItemsEventTest.php` | final class, plain PHPUnit `TestCase`, `#[Test]` attributes |
+<!-- AGENTS-GENERATED:END golden-samples -->
+
+## Heuristics (quick decisions)
+<!-- AGENTS-GENERATED:START heuristics -->
+| When | Do |
+|------|-----|
+| Adding class | Follow PSR-4 in `Classes/` (`Netresearch\Sync\`) |
+| Adding controller | Create in `Classes/Controller/`, extend `BaseSyncModuleController` |
+| Adding service | Create in `Classes/Service/` |
+| Running tasks | Check `make help` for available commands |
+| Adding dependency | Ask first - we minimize deps |
+| Unsure about pattern | Check Golden Samples above |
+<!-- AGENTS-GENERATED:END heuristics -->
+
+## Repository Settings
+<!-- AGENTS-GENERATED:START repo-settings -->
+- **Default branch:** `master`
+- **Merge strategy:** merge
+- **Signed commits:** required
+- **Required checks (rulesets):** `All security checks`, `CodeQL`, `Opengrep OSS`, `ci / All CI checks`, `scorecard`
+- **Active rulesets:** require-signed-commits, t3x-baseline, t3x-pull-request
+<!-- AGENTS-GENERATED:END repo-settings -->
+
+## Boundaries
+
+### Always Do
+- Run pre-commit checks before committing
+- Add tests for new code paths
+- Use conventional commit format: `type(scope): subject`
+- Use **atomic commits** (one logical change per commit); preserve signatures, keep bisection useful
+- **Show test output as evidence before claiming work is complete** — never say "try again", "should work now", "tested", "verified", or "all green" without pasted command output
+- Before any edit, verify `pwd` resolves inside the intended repo worktree — not `.bare/`, not `~/.claude/skills/…`, not `~/.claude/plugins/cache/…` (those are read-only caches that get clobbered on update)
+- For upstream dependency fixes: run **full** test suite, not just affected tests
+- Force-push only with `--force-with-lease`
+- Follow PSR-12 + TYPO3 CGL; `declare(strict_types=1);` in every PHP file
+
+### Ask First
+- Adding new dependencies
+- Modifying CI/CD configuration
+- Changing public API signatures
+- Repo-wide refactoring or rewrites
+- Operations that touch >3 repos (produce a dry-run plan first)
+
+### Never Do
+- Commit secrets, credentials, or sensitive data
+- Modify `.build/`, vendor/, or generated files
+- Push directly to master — open a PR
+- Merge a PR before all review threads are resolved
+- Squash commits during merge or rebase unless the user explicitly asked
+- Edit installed skill/plugin cache paths (`~/.claude/skills/`, `~/.claude/plugins/cache/`, `**/.bare/**`) — always the source worktree
+- Reply to review comments with bare "Addressed" or "Fixed" — cite the resolving commit SHA
+- Commit `composer.lock` — extension repos stay lock-free (it is gitignored)
+- Use `secrets: inherit` in reusable GitHub Actions workflows (pass secrets explicitly)
+- Modify core framework files
+
+## Contributing (for AI agents)
+- **Comprehension**: Understand the problem before submitting code. Read the linked issue, understand *why* the change is needed, not just *what* to change.
+- **Context**: Every PR must explain the trade-offs considered and link to the issue it addresses. Disclose AI assistance if the project requires it.
+- **Continuity**: Respond to review feedback. Drive-by PRs without follow-up will be closed.
+
+## Codebase State
+<!-- AGENTS-GENERATED:START codebase-state -->
+- Deprecated code exists: `Classes/Helper/Area.php` carries `@deprecated` (grep for `@deprecated`)
+- PHPStan runs at level 6 with baseline `Build/phpstan-baseline.neon` — do not grow the baseline
+<!-- AGENTS-GENERATED:END codebase-state -->
+
+## Scoped AGENTS.md (MUST read when working in these directories)
+<!-- AGENTS-GENERATED:START scope-index -->
+- `./Classes/AGENTS.md` — PHP classes: sync modules, services, events, DI
+- `./Tests/AGENTS.md` — PHPUnit unit test suite
+- `./Resources/AGENTS.md` — Fluid templates, XLIFF translations, CSS, icons
+- `./.github/workflows/AGENTS.md` — thin callers of netresearch reusable CI workflows
+<!-- AGENTS-GENERATED:END scope-index -->
+
+> **Agents**: When you read or edit files in a listed directory, you **must** load its AGENTS.md first. It contains directory-specific conventions that override this root file.
+
+## When instructions conflict
+The nearest `AGENTS.md` wins. Explicit user prompts override files.
+- For PHP-specific patterns, follow PSR standards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,0 +1,120 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — Classes
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+PHP source of the `nr_sync` backend extension (namespace `Netresearch\Sync\`, PSR-4 from `Classes/`). Sync-type-specific backend modules (assets, FAL, news, single page, table state) build SQL dump files and URL lists that target systems import; a scheduler task performs the import side.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Controller/BaseSyncModuleController.php` | Shared base for all sync backend module controllers |
+| `Table.php` | Controls table sync/dump generation |
+| `SyncList.php` / `SyncListManager.php` | Manage the list of pages/tables selected for sync |
+| `SyncLock.php` | Disables sync modules via extension configuration (`syncModuleLocked`) |
+| `Generator/Urls.php` | Generates files with the URL lists target systems must call |
+| `Middleware/ClearCache.php` | HTTP endpoint for clearing caches on target systems |
+| `Scheduler/SyncImportTask/Task.php` | Scheduler task importing dump files on targets |
+<!-- AGENTS-GENERATED:END filemap -->
+
+<!-- AGENTS-GENERATED:START golden-samples -->
+## Golden Samples (follow these patterns)
+| Pattern | Reference |
+|---------|-----------|
+| Backend module controller | `Controller/AssetSyncModuleController.php` |
+| DI service | `Service/StorageService.php` |
+| PSR-14 event | `Event/BeforeSyncEvent.php` |
+| Shared behavior | `Traits/DumpFileTrait.php` |
+<!-- AGENTS-GENERATED:END golden-samples -->
+
+<!-- AGENTS-GENERATED:START setup -->
+## Setup & environment
+- Install dev tooling: `composer install` (binaries in `.build/bin/`, vendor in `.build/vendor/`)
+- TYPO3 target: `^13.4` (see `../composer.json` / `../ext_emconf.php`)
+- Runtime dependency: `netresearch/nr-scheduler`; PHP extensions `ext-ftp`, `ext-zlib`
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START structure -->
+## Directory structure
+```
+Classes/
+  Command/         → console commands (ClearCache)
+  Controller/      → backend sync module controllers (Base/Asset/Fal/News/SinglePage/TableState)
+  Event/           → PSR-14 events (BeforeSync, AfterSync, FalSync, ModifyMenuItems, ModifyTableList)
+  EventListener/   → event listeners (FalSyncEventListener)
+  Generator/       → URL list generation
+  Helper/          → Area helper (contains @deprecated code)
+  Middleware/      → PSR-15 middleware (clear-cache endpoint)
+  Scheduler/       → SyncImportTask for target-side import
+  Service/         → ClearCacheService, StorageService
+  Traits/          → shared behavior (DumpFile, DatabaseConnection, FlashMessage, …)
+  ViewHelpers/     → Fluid ViewHelpers (Backend, File, Folder, Format, Math)
+```
+Module registration lives in `../Configuration/Backend/Modules.php`, DI in `../Configuration/Services.yaml`, middleware in `../Configuration/RequestMiddlewares.php`.
+<!-- AGENTS-GENERATED:END structure -->
+
+<!-- AGENTS-GENERATED:START commands -->
+## Build & tests
+| Task | Command |
+|------|---------|
+| PHP lint | `composer ci:test:php:lint` |
+| PHPStan | `composer ci:test:php:phpstan` |
+| Code style check | `composer ci:test:php:cgl` |
+| Code style fix | `composer ci:cgl` |
+| Rector dry-run | `composer ci:test:php:rector` |
+| Unit tests | `composer ci:test:php:unit` |
+| All checks | `composer ci:test` |
+<!-- AGENTS-GENERATED:END commands -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Code style & conventions
+- **PSR-12** + TYPO3 CGL, enforced via `composer ci:test:php:cgl` (config `../Build/.php-cs-fixer.dist.php`)
+- Strict types: `declare(strict_types=1);` in all PHP files
+- Namespace: `Netresearch\Sync\` (PSR-4 from `Classes/`)
+- Use constructor dependency injection via `../Configuration/Services.yaml`; avoid `GeneralUtility::makeInstance()` in new code
+- Extend `BaseSyncModuleController` for new sync module controllers
+- Emit/extend PSR-14 events in `Event/` for extensibility instead of hooks
+- Never use raw SQL strings — use the Doctrine `QueryBuilder` (see `Traits/DatabaseConnectionTrait.php`)
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security & safety
+- This extension writes SQL dump files and touches multiple systems — treat all path and table input as untrusted
+- **Always use QueryBuilder** with named parameters — never string-concatenated SQL
+- **Escape output** in Fluid: `{variable}` auto-escapes, use `<f:format.raw>` only when safe
+- **Access checks**: backend modules must respect BE user permissions (`$GLOBALS['BE_USER']`)
+- Never log or dump credentials of target systems
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR/commit checklist
+- [ ] `composer ci:test` passes (lint, phpstan, rector, cgl, unit)
+- [ ] PHPStan clean without adding entries to `../Build/phpstan-baseline.neon`
+- [ ] New events/services registered in `../Configuration/` where required
+- [ ] `../ext_tables.sql` updated if DB fields change
+- [ ] No deprecated TYPO3 APIs introduced
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real code in this repo over generic examples.**
+> See **Golden Samples** section above for files that demonstrate correct patterns.
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- TYPO3 Documentation: https://docs.typo3.org
+- Core API: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
+- Backend module API: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Backend/BackendModules.html
+- Check existing sync module controllers for patterns
+- Review root AGENTS.md for project-wide conventions; component map in `../docs/ARCHITECTURE.md`
+<!-- AGENTS-GENERATED:END help -->
+
+<!-- AGENTS-GENERATED:START skill-reference -->
+## Skill Reference
+> For TYPO3 extension standards, TER compliance, and conformance checks:
+> **Invoke skill:** `typo3-conformance`
+<!-- AGENTS-GENERATED:END skill-reference -->

--- a/Classes/CLAUDE.md
+++ b/Classes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -1,0 +1,73 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — Resources
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+Static resources of the `nr_sync` backend extension: Fluid templates and partials for the sync backend modules, XLIFF translations (Crowdin-managed), CSS, and SVG icons.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START setup -->
+## Setup & environment
+- No build/preprocessing step — files are shipped as-is (no bundler, no SCSS pipeline)
+- Templates are rendered by the backend module controllers in `../Classes/Controller/`
+- Translations: `en` is the source language; other `*.locallang*.xlf` files come from Crowdin (project `typo3-extension-nr-sync`) — do not hand-edit non-English files
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START structure -->
+## Directory structure
+```
+Resources/
+  Private/
+    Language/    → XLIFF: locallang / locallang_mod / locallang_mod_sync / locallang_scheduler, English source + per-locale prefixed copies
+    Partials/    → Fluid partials (SyncList, SyncStatus, WaitList, Checkboxes, …)
+    Templates/   → Fluid templates (Backend/)
+  Public/
+    Css/         → Administration.css (backend module styling)
+    Icons/       → Extension.svg, Module.svg
+```
+<!-- AGENTS-GENERATED:END structure -->
+
+<!-- AGENTS-GENERATED:START commands -->
+## Build & tests
+- No dedicated resource build or test commands exist
+- After template changes, run `composer ci:test` at repo root to keep the overall gate green
+- Verify rendering manually in a TYPO3 backend (module: nr_sync)
+<!-- AGENTS-GENERATED:END commands -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Code style & conventions
+- Fluid: keep logic in controllers/ViewHelpers, not in templates
+- Reuse existing partials (`Private/Partials/`) before adding new markup
+- Translation keys: add to English `locallang*.xlf` only; reference via `LLL:EXT:nr_sync/Resources/Private/Language/…`
+- SVG icons: registered in `../Configuration/Icons.php`
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security & safety
+- Fluid `{variable}` output auto-escapes — use `<f:format.raw>` only for values that are provably safe
+- Never store secrets or target-system credentials in resource files
+- Backend templates render sync/table data — treat record values as untrusted input
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR/commit checklist
+- [ ] New translation keys added to the English XLIFF source files only
+- [ ] XLIFF files are valid XML
+- [ ] Templates keep logic-free (no business logic in Fluid)
+- [ ] No sensitive data in resources
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Patterns to Follow
+> **Prefer looking at real code in this repo over generic examples.**
+> Existing partials in `Private/Partials/` demonstrate the current Fluid conventions.
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- Check how templates are consumed by controllers in `../Classes/Controller/`
+- Fluid reference: https://docs.typo3.org/other/typo3fluid/fluid/main/en-us/
+- XLIFF handling: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Localization/
+- Check root AGENTS.md for project conventions
+<!-- AGENTS-GENERATED:END help -->

--- a/Resources/CLAUDE.md
+++ b/Resources/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,0 +1,98 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure. Last updated: 2026-08-19 -->
+
+# AGENTS.md — Tests
+
+<!-- AGENTS-GENERATED:START overview -->
+## Overview
+PHPUnit unit test suite for `nr_sync`. Only `Tests/Unit/` exists — there is no functional test suite. Config: `../Build/phpunit.xml` (PHPUnit 10.5 schema, strict about output/risky/warnings). **Use the `typo3-testing` skill** for comprehensive guidance.
+<!-- AGENTS-GENERATED:END overview -->
+
+<!-- AGENTS-GENERATED:START filemap -->
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Unit/Event/BeforeSyncEventTest.php` | Tests for the BeforeSync PSR-14 event |
+| `Unit/Event/AfterSyncEventTest.php` | Tests for the AfterSync PSR-14 event |
+| `Unit/Event/ModifyMenuItemsEventTest.php` | Tests for the ModifyMenuItems event |
+| `Unit/Event/ModifyTableListEventTest.php` | Tests for the ModifyTableList event |
+<!-- AGENTS-GENERATED:END filemap -->
+
+<!-- AGENTS-GENERATED:START golden-samples -->
+## Golden Samples (follow these patterns)
+| Pattern | Reference |
+|---------|-----------|
+| Unit test | `Unit/Event/ModifyMenuItemsEventTest.php` |
+<!-- AGENTS-GENERATED:END golden-samples -->
+
+<!-- AGENTS-GENERATED:START setup -->
+## Setup
+- `composer install` at repo root — PHPUnit lands in `.build/bin/phpunit` (via `netresearch/typo3-ci-workflows` dev dependency)
+- No database, TYPO3 instance, or ddev required: the suite is pure unit tests
+<!-- AGENTS-GENERATED:END setup -->
+
+<!-- AGENTS-GENERATED:START structure -->
+## Test Structure
+```
+Tests/
+└── Unit/          # Fast, isolated unit tests (autoload-dev: Netresearch\Sync\Tests\)
+    └── Event/     # PSR-14 event tests
+```
+<!-- AGENTS-GENERATED:END structure -->
+
+<!-- AGENTS-GENERATED:START commands -->
+## Running Tests (from repo root)
+| Type | Command |
+|------|---------|
+| Unit tests | `composer ci:test:php:unit` (= `make test-unit`) |
+| Single file | `.build/bin/phpunit --configuration Build/phpunit.xml Tests/Unit/Event/BeforeSyncEventTest.php` |
+| Filter by name | `.build/bin/phpunit --configuration Build/phpunit.xml --filter methodName` |
+<!-- AGENTS-GENERATED:END commands -->
+
+<!-- AGENTS-GENERATED:START patterns -->
+## Key Patterns
+- Test classes are `final` and extend `PHPUnit\Framework\TestCase` directly (no TYPO3 testing-framework base class in use)
+- Test methods use the `#[Test]` attribute (`PHPUnit\Framework\Attributes\Test`)
+- PHPUnit config is strict: `failOnRisky`, `failOnWarning`, `beStrictAboutOutputDuringTests` — keep test output pristine
+- Coverage source is `../Classes/` (see `../Build/phpunit.xml`)
+<!-- AGENTS-GENERATED:END patterns -->
+
+<!-- AGENTS-GENERATED:START code-style -->
+## Code Style
+- Test class name matches source: `MyClass` → `MyClassTest`; namespace `Netresearch\Sync\Tests\Unit\…`
+- One assertion concept per test
+- Use data providers for multiple similar cases
+- Mock external services, never real HTTP/FTP calls
+<!-- AGENTS-GENERATED:END code-style -->
+
+<!-- AGENTS-GENERATED:START security -->
+## Security
+- Never place real hostnames, credentials, or customer data in tests — use obvious dummies
+- Mock filesystem/FTP/database interactions; tests must not touch the network or write outside temp dirs
+<!-- AGENTS-GENERATED:END security -->
+
+<!-- AGENTS-GENERATED:START examples -->
+## Examples
+> **Prefer looking at real tests in this repo over generic examples.**
+> `Unit/Event/ModifyMenuItemsEventTest.php` shows the house style: final class, `#[Test]` attributes, one behavior per method.
+<!-- AGENTS-GENERATED:END examples -->
+
+<!-- AGENTS-GENERATED:START checklist -->
+## PR Checklist
+- [ ] All tests pass: `composer ci:test:php:unit`
+- [ ] New functionality has tests
+- [ ] No hardcoded credentials or paths
+- [ ] Tests produce no output (strict PHPUnit config fails on it)
+<!-- AGENTS-GENERATED:END checklist -->
+
+<!-- AGENTS-GENERATED:START help -->
+## When stuck
+- PHPUnit 10 docs: https://docs.phpunit.de/en/10.5/
+- Check `../Build/phpunit.xml` for suite/coverage configuration
+- Review root AGENTS.md and `../docs/ARCHITECTURE.md` for component context
+<!-- AGENTS-GENERATED:END help -->
+
+<!-- AGENTS-GENERATED:START skill-reference -->
+## Skill Reference
+> For comprehensive TYPO3 testing guidance including fixtures, mocking, and CI setup:
+> **Invoke skill:** `typo3-testing`
+<!-- AGENTS-GENERATED:END skill-reference -->

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,36 @@
+# Architecture
+
+Agent-facing component map of `netresearch/nr-sync` (TYPO3 extension key `nr_sync`). Every path below is verified against the tree; update this file when components move.
+
+## System overview
+
+The extension prepares content of a TYPO3 source system (typically production) for synchronization to one or more target systems. Editors use sync-type-specific backend modules to select pages/tables; the extension writes SQL dump files and URL lists. It does **not** transfer them itself — target systems import the dumps via a scheduler task and get their caches cleared through an HTTP middleware endpoint.
+
+## Components
+
+| Component | Path | Responsibility |
+|-----------|------|----------------|
+| Backend module controllers | `Classes/Controller/` | One controller per sync type (Asset, FAL, News, SinglePage, TableState), all extending `BaseSyncModuleController.php`; registered in `Configuration/Backend/Modules.php` |
+| Sync list | `Classes/SyncList.php`, `Classes/SyncListManager.php` | Track pages/tables selected for synchronization |
+| Dump generation | `Classes/Table.php`, `Classes/Traits/DumpFileTrait.php` | Control table sync and SQL dump file creation |
+| URL list generation | `Classes/Generator/Urls.php` | Write files with URLs target systems must call |
+| Sync lock | `Classes/SyncLock.php` | Disable sync modules via extension configuration (`ext_conf_template.txt`: `syncModuleLocked`) |
+| Sync statistics | `Classes/SyncStats.php`, `ext_tables.sql` | Per-table sync state in `tx_nrsync_syncstat` |
+| Import task | `Classes/Scheduler/SyncImportTask/` | Scheduler task (extends `netresearch/nr-scheduler` `AbstractTask`) importing the sync MySQL files on targets; registered in `ext_localconf.php` |
+| Cache clearing | `Classes/Service/ClearCacheService.php`, `Classes/Middleware/ClearCache.php`, `Classes/Command/ClearCache.php` | Clear caches for synced tables: service, frontend middleware endpoint (`Configuration/RequestMiddlewares.php`), console command `sync:cache:clear` |
+| Extensibility | `Classes/Event/`, `Classes/EventListener/` | PSR-14 events (BeforeSync, AfterSync, FalSync, ModifyMenuItems, ModifyTableList) documented in `README.md` |
+| Storage | `Classes/Service/StorageService.php`, `Classes/Helper/Area.php`, `Configuration/DefaultAreaConfiguration.php` | Resolve sync storage/areas and target directories (`Area` contains `@deprecated` code) |
+| View layer | `Classes/ViewHelpers/`, `Resources/Private/` | Fluid ViewHelpers, templates, partials for the backend modules |
+| DI configuration | `Configuration/Services.yaml` | Autowiring; backend controllers tagged `backend.controller`, FalSync listener tagged `event.listener` |
+
+## Data flow
+
+1. Editor opens a sync backend module (source system); `SyncLock` may block usage via extension configuration.
+2. Controller builds the sync list (`SyncList`/`SyncListManager`), dispatches `BeforeSyncEvent`, and writes SQL dump files (`Table`, `DumpFileTrait`) plus URL lists (`Generator/Urls`) into the sync storage.
+3. Sync state per table is recorded in `tx_nrsync_syncstat` (`SyncStats`); `AfterSyncEvent` is dispatched.
+4. On each target system, the `SyncImportTask` scheduler task imports the dump files and triggers cache clearing (`ClearCacheService`), also reachable via the `nr/nr-sync/clear-cache` middleware and the `sync:cache:clear` command.
+
+## Key decisions
+
+- No ADR directory exists. Behavioral contracts live in: `README.md` (PSR-14 event usage), `.github/workflows/checks.yml` (gate/required-check rationale, in-file comments), and `AGENTS.md` files (working conventions).
+- There is no `Tests/Architecture/` (phpat) suite; dependency rules are not machine-enforced.

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,8 @@
+# Execution plans
+
+Multi-session work plans for AI agents working on this repository.
+
+- `active/` — plans currently being executed (create on demand)
+- `completed/` — finished plans kept for reference (create on demand)
+
+Keep one plan per file, named `YYYY-MM-DD-short-slug.md`. A plan lists goal, constraints, ordered steps with verification commands, and a completion checklist. Update the plan as steps finish so an interrupted session can resume from the file alone.

--- a/scripts/verify-harness.sh
+++ b/scripts/verify-harness.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+# verify-harness.sh — Portable harness consistency checker
+# Checks AGENTS.md and related files for agent harness maturity.
+# Dependencies: coreutils + git (jq optional, graceful fallback)
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+ERRORS=0
+WARNINGS=0
+FORMAT=""
+MAX_LEVEL=3
+SINGLE_CHECK=""
+STATUS_ONLY=false
+PLATFORM="${PLATFORM:-}"
+
+# Collected output lines (for final rendering)
+declare -a OUTPUT_LINES=()
+declare -a GITHUB_LINES=()
+declare -a GITLAB_LINES=()
+
+# Per-level pass/total counters
+declare -A LEVEL_PASS=( [1]=0 [2]=0 [3]=0 )
+declare -A LEVEL_TOTAL=( [1]=0 [2]=0 [3]=0 )
+
+# Track the first failing level-1 suggestion for --status
+NEXT_STEP=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: verify-harness.sh [OPTIONS]
+
+Verify agent harness consistency in the current repository.
+Must be run from the repo root.
+
+Options:
+  --format=text     Plain text output (default for terminals)
+  --format=github   GitHub Actions annotations (auto-detected in CI)
+  --format=gitlab   GitLab CI section annotations (auto-detected in CI)
+  --platform=P      Target platform: github, gitlab or forgejo (auto-detected
+                    from CI environment or git remote URL if not specified)
+  --level=N         Only check up to level N (1, 2, or 3; default: all)
+  --check=NAME      Run single check category: refs, commands, drift, structure
+  --status          Show current maturity level summary only
+  --help            Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  Errors found (Level 1/2 failures)
+  2  Only warnings (Level 3 suggestions)
+USAGE
+    exit 0
+}
+
+# Detect output format: github if running in CI, otherwise text
+detect_format() {
+    if [[ -n "$FORMAT" ]]; then
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        FORMAT="github"
+    elif [[ "${GITLAB_CI:-}" == "true" ]]; then
+        FORMAT="gitlab"
+    else
+        FORMAT="text"
+    fi
+}
+
+# Detect hosting platform from CI env, git remote, or flag
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then
+        if [[ "$PLATFORM" != "github" && "$PLATFORM" != "gitlab" && "$PLATFORM" != "forgejo" ]]; then
+            echo "Error: Unsupported PLATFORM '${PLATFORM}'. Expected 'github', 'gitlab' or 'forgejo'." >&2
+            exit 1
+        fi
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        # Forgejo/Gitea Actions also export GITHUB_ACTIONS=true; tell them apart
+        # by the server URL — github.com (or a *.github.* Enterprise host) is real
+        # GitHub, anything else is a self-hosted Forgejo/Gitea instance.
+        if [[ -n "${GITHUB_SERVER_URL:-}" && "${GITHUB_SERVER_URL}" != *"github."* ]]; then
+            PLATFORM="forgejo"
+        else
+            PLATFORM="github"
+        fi
+        return
+    fi
+    if [[ "${GITLAB_CI:-}" == "true" ]]; then
+        PLATFORM="gitlab"
+        return
+    fi
+    local remote_url=""
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$remote_url" == *"forgejo"* || "$remote_url" == *"gitea"* ]]; then
+        PLATFORM="forgejo"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        PLATFORM="github"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        PLATFORM="gitlab"
+    elif [[ -f ".gitlab-ci.yml" ]]; then
+        # Infer GitLab from CI config presence (e.g. self-hosted GitLab)
+        PLATFORM="gitlab"
+    elif [[ -d ".forgejo" || -d ".gitea" ]]; then
+        # Infer Forgejo/Gitea from config presence (self-hosted)
+        PLATFORM="forgejo"
+    elif [[ -d ".github" ]]; then
+        PLATFORM="github"
+    else
+        PLATFORM="github"
+    fi
+}
+
+# Record a passing check
+pass() {
+    local level="$1"
+    local msg="$2"
+    (( LEVEL_PASS[$level]++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  PASS|${level}|${msg}")
+}
+
+# Record a failing check (error)
+fail() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( ERRORS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  FAIL|${level}|${msg}")
+    GITHUB_LINES+=("::error file=${file}::${msg} -- required for Level ${level} harness maturity")
+    GITLAB_LINES+=("ERROR: [Level ${level}] ${msg}${file:+ (${file})}")
+    # Capture first actionable suggestion for --status
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# Record a warning
+warn() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( WARNINGS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  WARN|${level}|${msg}")
+    GITHUB_LINES+=("::warning file=${file}::${msg}")
+    GITLAB_LINES+=("WARNING: [Level ${level}] ${msg}${file:+ (${file})}")
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Level 1 checks — Basic
+# ---------------------------------------------------------------------------
+check_agents_md_exists() {
+    if [[ -f "AGENTS.md" ]]; then
+        pass 1 "AGENTS.md exists"
+    else
+        fail 1 "AGENTS.md missing at repo root"
+    fi
+}
+
+check_agents_md_length() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "AGENTS.md length check skipped (file missing)"
+        return
+    fi
+    local lines
+    lines=$(wc -l < "AGENTS.md")
+    if (( lines < 150 )); then
+        pass 1 "AGENTS.md is index-format (${lines} lines)"
+    else
+        fail 1 "AGENTS.md is ${lines} lines (should be under 150)"
+    fi
+}
+
+check_agents_md_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "Commands section check skipped (AGENTS.md missing)"
+        return
+    fi
+    if grep -qi '^## *\(available \)\?commands' "AGENTS.md"; then
+        pass 1 "Commands section found"
+    else
+        fail 1 "AGENTS.md missing ## Commands section"
+    fi
+}
+
+check_docs_exists() {
+    if [[ -d "docs" ]]; then
+        pass 1 "docs/ directory exists"
+    else
+        fail 1 "docs/ directory missing" ""
+    fi
+}
+
+run_level1() {
+    check_agents_md_exists
+    check_agents_md_length
+    check_agents_md_commands
+    check_docs_exists
+}
+
+# ---------------------------------------------------------------------------
+# Level 2 checks — Verified
+# ---------------------------------------------------------------------------
+
+# Check that all local file references in AGENTS.md resolve
+check_refs() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Reference check skipped (AGENTS.md missing)"
+        return
+    fi
+    local has_broken=false
+    # Extract markdown links: [text](path) — skip http(s):// and #anchors
+    while IFS= read -r ref; do
+        # Strip anchor (#...) and query string (?...)
+        local clean
+        clean="${ref%%#*}"
+        clean="${clean%%\?*}"
+        # Skip empty after stripping
+        [[ -z "$clean" ]] && continue
+        # Skip URLs
+        [[ "$clean" =~ ^https?:// ]] && continue
+        # Check if file/dir exists
+        if [[ ! -e "$clean" ]]; then
+            warn 2 "Broken reference in AGENTS.md: ${ref} -> ${clean} not found"
+            has_broken=true
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "AGENTS.md" 2>/dev/null || true)
+
+    if [[ "$has_broken" == false ]]; then
+        pass 2 "All references resolve"
+    fi
+}
+
+# Check that documented commands have matching targets/scripts
+check_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Command check skipped (AGENTS.md missing)"
+        return
+    fi
+
+    local found_any=false
+
+    # -- Makefile targets --
+    if [[ -f "Makefile" ]]; then
+        found_any=true
+        local has_make_issue=false
+        while IFS= read -r target; do
+            # Check if Makefile defines this target (pattern: "target:" at start of line)
+            if ! grep -qE "^${target}[[:space:]]*:" "Makefile"; then
+                warn 2 "make ${target}: no matching Makefile target (warning)"
+                has_make_issue=true
+            fi
+        done < <(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_make_issue" == false ]]; then
+            local make_count
+            make_count=$(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$make_count" -gt 0 ]]; then
+                pass 2 "All make targets verified (${make_count} targets)"
+            fi
+        fi
+    fi
+
+    # -- composer.json scripts --
+    if [[ -f "composer.json" ]]; then
+        found_any=true
+        local has_composer_issue=false
+        # Built-in composer commands that are NOT user-defined scripts
+        local composer_builtins="install|update|require|remove|dump-autoload|dumpautoload|clear-cache|clearcache|config|create-project|exec|global|init|outdated|prohibits|why|why-not|search|self-update|selfupdate|show|status|validate|archive|browse|check-platform-reqs|diagnose|fund|licenses|run-script|suggests|upgrade"
+        while IFS= read -r script; do
+            # Skip built-in composer commands
+            if echo "$script" | grep -qE "^(${composer_builtins})$"; then
+                continue
+            fi
+            # Look for the script name in composer.json's scripts section
+            # Using grep since jq is optional
+            if ! grep -qE "\"${script}\"" "composer.json"; then
+                warn 2 "composer ${script}: no matching composer.json script (warning)"
+                has_composer_issue=true
+            fi
+        done < <(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_composer_issue" == false ]]; then
+            local composer_count
+            composer_count=$(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$composer_count" -gt 0 ]]; then
+                pass 2 "All composer scripts verified (${composer_count} scripts)"
+            fi
+        fi
+    fi
+
+    # -- package.json scripts --
+    if [[ -f "package.json" ]]; then
+        found_any=true
+        local has_npm_issue=false
+        while IFS= read -r script; do
+            if ! grep -qE "\"${script}\"" "package.json"; then
+                warn 2 "npm run ${script}: no matching package.json script (warning)"
+                has_npm_issue=true
+            fi
+        done < <(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_npm_issue" == false ]]; then
+            local npm_count
+            npm_count=$(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$npm_count" -gt 0 ]]; then
+                pass 2 "All npm scripts verified (${npm_count} scripts)"
+            fi
+        fi
+    fi
+
+    if [[ "$found_any" == false ]]; then
+        pass 2 "No build system files found to check commands against"
+    fi
+}
+
+check_architecture_doc() {
+    if [[ -f "docs/ARCHITECTURE.md" ]]; then
+        pass 2 "docs/ARCHITECTURE.md exists"
+    else
+        fail 2 "docs/ARCHITECTURE.md missing" ""
+    fi
+}
+
+check_ci_workflow() {
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -f ".gitlab-ci.yml" ]]; then
+            # Search root file and all include:local files for harness job
+            local found_harness=false
+            if grep -qE "harness-verify|verify-harness" ".gitlab-ci.yml"; then
+                found_harness=true
+            else
+                # Check files referenced via include:local (supports globs).
+                # Portable parser using sed/awk — handles common GitLab CI forms:
+                #   include: { local: 'path' }
+                #   include:
+                #     - local: 'path'
+                #   include:
+                #     - local:
+                #         - path1
+                #         - path2
+                # Skips PCRE (-P) and lookaround for BSD/macOS grep portability.
+                while IFS= read -r inc_pattern; do
+                    [[ -z "$inc_pattern" ]] && continue
+                    # shellcheck disable=SC2086
+                    for inc_file in $inc_pattern; do
+                        if [[ -f "$inc_file" ]] && grep -qE "harness-verify|verify-harness" "$inc_file"; then
+                            found_harness=true
+                            break 2
+                        fi
+                    done
+                done < <(awk '
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*\[/ {
+                        # inline list form: local: [a.yml, b.yml]
+                        s=$0; sub(/.*local:[[:space:]]*\[/,"",s); sub(/\].*/,"",s);
+                        n=split(s, a, /[[:space:]]*,[[:space:]]*/);
+                        for (i=1;i<=n;i++) print a[i]; next
+                    }
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*[^[:space:]\[]/ {
+                        # scalar form: local: path or - local: path
+                        s=$0; sub(/.*local:[[:space:]]*/,"",s); print s; next
+                    }
+                ' ".gitlab-ci.yml" 2>/dev/null | tr -d "'\"" || true)
+            fi
+            if [[ "$found_harness" == true ]]; then
+                pass 2 "CI harness job found in GitLab CI config"
+            else
+                warn 2 "CI config exists (.gitlab-ci.yml) but no harness-verify job found"
+            fi
+        else
+            fail 2 "CI harness workflow missing -- create .gitlab-ci.yml with a harness-verify job" ""
+        fi
+    elif [[ "$PLATFORM" == "forgejo" ]]; then
+        if [[ -f ".forgejo/workflows/harness-verify.yml" || -f ".gitea/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .forgejo/workflows/harness-verify.yml" ""
+        fi
+    else
+        if [[ -f ".github/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .github/workflows/harness-verify.yml" ""
+        fi
+    fi
+}
+
+run_level2() {
+    check_refs
+    check_commands
+    check_architecture_doc
+    check_ci_workflow
+}
+
+# ---------------------------------------------------------------------------
+# Level 3 checks — Enforced
+# ---------------------------------------------------------------------------
+
+check_hooks_autosetup() {
+    local found=false
+    local via=""
+
+    # Check .envrc for hooksPath
+    if [[ -f ".envrc" ]] && grep -q "hooksPath" ".envrc"; then
+        found=true
+        via=".envrc"
+    fi
+
+    # Check for Husky
+    if [[ -d ".husky" ]]; then
+        found=true
+        via=".husky"
+    fi
+
+    # Check composer.json for post-install-cmd with hooks
+    if [[ -f "composer.json" ]] && grep -q "post-install-cmd" "composer.json"; then
+        if grep -q "hook" "composer.json"; then
+            found=true
+            via="composer.json post-install-cmd"
+        fi
+    fi
+
+    if [[ "$found" == true ]]; then
+        pass 3 "Git hooks auto-setup via ${via}"
+    else
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+    fi
+}
+
+check_pr_template() {
+    if [[ "$PLATFORM" == "forgejo" ]]; then
+        # Forgejo/Gitea honour PR templates under .forgejo/, .gitea/ or .github/
+        local f
+        for f in .forgejo/pull_request_template.md .gitea/pull_request_template.md \
+                 .forgejo/PULL_REQUEST_TEMPLATE.md .gitea/PULL_REQUEST_TEMPLATE.md \
+                 .github/pull_request_template.md; do
+            if [[ -f "$f" ]]; then
+                pass 3 "PR template exists ($f)"
+                return
+            fi
+        done
+        warn 3 "PR template missing (create .forgejo/pull_request_template.md)"
+        return
+    fi
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -d ".gitlab/merge_request_templates" ]]; then
+            local tmpl_count
+            tmpl_count=$(find .gitlab/merge_request_templates -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+            if (( tmpl_count > 0 )); then
+                pass 3 "MR template exists (.gitlab/merge_request_templates/, ${tmpl_count} template(s))"
+                return
+            fi
+        fi
+        warn 3 "MR template missing (create .gitlab/merge_request_templates/Default.md)"
+    else
+        if [[ -f ".github/pull_request_template.md" ]]; then
+            pass 3 "PR template exists (repo-level)"
+            return
+        fi
+        if [[ -d ".github/PULL_REQUEST_TEMPLATE" ]]; then
+            pass 3 "PR template exists (directory form)"
+            return
+        fi
+        local org=""
+        org=$(git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
+        if [[ -n "$org" ]]; then
+            local api_result=""
+            api_result=$(gh api "repos/${org}/.github/contents/pull_request_template.md" --jq '.name' 2>/dev/null || true)
+            if [[ "$api_result" == "pull_request_template.md" ]]; then
+                pass 3 "PR template exists (org-level via ${org}/.github)"
+                return
+            fi
+        fi
+        warn 3 "PR template missing (.github/pull_request_template.md or org-level)"
+    fi
+}
+
+check_drift() {
+    # Skip if git is not available
+    if ! command -v git &>/dev/null; then
+        pass 3 "Drift check skipped (git not available)"
+        return
+    fi
+
+    # Skip if not in a git repo
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (not a git repository)"
+        return
+    fi
+
+    # Skip if no parent commit (initial commit)
+    if ! git rev-parse HEAD~1 &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (no parent commit)"
+        return
+    fi
+
+    # Check if build/CI files changed in last commit
+    local build_files_changed=false
+    local agents_changed=false
+
+    while IFS= read -r changed_file; do
+        case "$changed_file" in
+            Makefile|composer.json|package.json|.github/workflows/*|.gitlab-ci.yml|.forgejo/workflows/*|.gitea/workflows/*)
+                build_files_changed=true
+                ;;
+            AGENTS.md)
+                agents_changed=true
+                ;;
+        esac
+    done < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+
+    if [[ "$build_files_changed" == true && "$agents_changed" == false ]]; then
+        warn 3 "Potential drift: build/CI files changed in last commit but AGENTS.md was not updated"
+    else
+        pass 3 "No drift detected"
+    fi
+}
+
+run_level3() {
+    check_hooks_autosetup
+    check_pr_template
+    check_drift
+}
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+render_text() {
+    echo "Agent Harness Verification"
+    echo "=========================="
+    echo ""
+
+    local current_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for line in "${OUTPUT_LINES[@]}"; do
+        local kind level msg
+        kind="${line%%|*}"
+        local rest="${line#*|}"
+        level="${rest%%|*}"
+        msg="${rest#*|}"
+        kind="${kind#"${kind%%[![:space:]]*}"}" # trim leading whitespace
+
+        # Print level header when level changes
+        if (( level != current_level )); then
+            if (( current_level != 0 )); then
+                echo ""
+            fi
+            echo "Level ${level} -- ${level_names[$level]}"
+            current_level=$level
+        fi
+
+        case "$kind" in
+            PASS) echo "  ✓ ${msg}" ;;
+            FAIL) echo "  ✗ ${msg}" ;;
+            WARN) echo "  ! ${msg}" ;;
+        esac
+    done
+
+    echo ""
+
+    # Summary line
+    local maturity_level=0
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status="COMPLETE"
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        maturity_level=1
+    elif (( maturity_level < 3 )); then
+        # Check if next level is partially done
+        local next_lvl=$(( maturity_level + 1 ))
+        if (( ${LEVEL_TOTAL[$next_lvl]} > 0 && ${LEVEL_PASS[$next_lvl]} < ${LEVEL_TOTAL[$next_lvl]} )); then
+            status="PARTIAL"
+        fi
+    fi
+
+    echo "Summary: Level ${maturity_level} ${status} | ${ERRORS} error(s), ${WARNINGS} warning(s)"
+}
+
+render_github() {
+    if (( ${#GITHUB_LINES[@]} > 0 )); then
+        for line in "${GITHUB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+}
+
+render_gitlab() {
+    local ts
+    ts=$(date +%s)
+    echo -e "\e[0Ksection_start:${ts}:harness_verify[collapsed=false]\r\e[0KAgent Harness Verification"
+    if (( ${#GITLAB_LINES[@]} > 0 )); then
+        for line in "${GITLAB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+    echo ""
+    echo "Summary: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+    echo -e "\e[0Ksection_end:${ts}:harness_verify\r\e[0K"
+}
+
+render_status() {
+    # Determine highest fully-passing level
+    local maturity_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        # Display as Level 1 when no level is fully complete
+        local display_level=1
+        echo "Harness Maturity: Level ${display_level} (${level_names[$display_level]}) -- ${status}"
+    else
+        echo "Harness Maturity: Level ${maturity_level} (${level_names[$maturity_level]}) -- COMPLETE"
+    fi
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 )); then
+            echo "  Level ${lvl}: ${LEVEL_PASS[$lvl]}/${LEVEL_TOTAL[$lvl]} checks pass"
+        fi
+    done
+
+    if [[ -n "$NEXT_STEP" ]]; then
+        echo "Next step: ${NEXT_STEP}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --format=*)
+                FORMAT="${1#--format=}"
+                ;;
+            --platform=*)
+                PLATFORM="${1#--platform=}"
+                if [[ ! "$PLATFORM" =~ ^(github|gitlab|forgejo)$ ]]; then
+                    echo "Error: --platform must be 'github', 'gitlab' or 'forgejo'" >&2
+                    exit 1
+                fi
+                ;;
+            --level=*)
+                MAX_LEVEL="${1#--level=}"
+                if [[ ! "$MAX_LEVEL" =~ ^[123]$ ]]; then
+                    echo "Error: --level must be 1, 2, or 3" >&2
+                    exit 1
+                fi
+                ;;
+            --check=*)
+                SINGLE_CHECK="${1#--check=}"
+                ;;
+            --status)
+                STATUS_ONLY=true
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Run with --help for usage info" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    detect_format
+    detect_platform
+
+    # Run single check category if requested
+    if [[ -n "$SINGLE_CHECK" ]]; then
+        case "$SINGLE_CHECK" in
+            refs)       check_refs ;;
+            commands)   check_commands ;;
+            drift)      check_drift ;;
+            structure)
+                check_agents_md_exists
+                check_docs_exists
+                check_architecture_doc
+                check_ci_workflow
+                check_pr_template
+                ;;
+            *)
+                echo "Unknown check: ${SINGLE_CHECK}" >&2
+                echo "Valid checks: refs, commands, drift, structure" >&2
+                exit 1
+                ;;
+        esac
+    else
+        # Run all checks up to MAX_LEVEL
+        if (( MAX_LEVEL >= 1 )); then
+            run_level1
+        fi
+        if (( MAX_LEVEL >= 2 )); then
+            run_level2
+        fi
+        if (( MAX_LEVEL >= 3 )); then
+            run_level3
+        fi
+    fi
+
+    # Render output
+    if [[ "$STATUS_ONLY" == true ]]; then
+        render_status
+    elif [[ "$FORMAT" == "github" ]]; then
+        render_github
+    elif [[ "$FORMAT" == "gitlab" ]]; then
+        render_gitlab
+    else
+        render_text
+    fi
+
+    # Exit code
+    if (( ERRORS > 0 )); then
+        exit 1
+    elif (( WARNINGS > 0 )); then
+        exit 2
+    else
+        exit 0
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
Closes #51

## Explain the details

The repo had no agent documentation (harness Level 1 NONE). This PR generates and curates the full AGENTS.md set and adds agent-harness Level 2/3 infrastructure, mirroring netresearch/t3x-rte_ckeditor_image#888 / netresearch/t3x-rte_ckeditor_image#890.

- Root `AGENTS.md` (139 lines, under the 150-line harness cap): verified command table (composer scripts + make targets), file map, golden samples, boundaries, verified repository settings (rulesets/required checks read from the GitHub API), scope index. Version pins avoided — the extension version is referenced via `ext_emconf.php`.
- Scoped `AGENTS.md` for `Classes/`, `Tests/`, `Resources/`, `.github/workflows/` — generator output was curated line by line: fixed wrong composer script names, wrong namespace (`Netresearch\Sync\`, not `netresearch\nr_sync\`), removed ddev/functional-test/runTests.sh/CODEOWNERS claims that do not apply to this repo, replaced generic Node.js workflow examples with the actual thin-caller-of-reusables pattern, and made all cross-scope path references scope-relative.
- `CLAUDE.md` symlink next to every AGENTS.md (no `Documentation/` scope needed — that directory only holds README images).
- `docs/ARCHITECTURE.md`: component map with all paths verified against the tree; `docs/exec-plans/README.md` for multi-session plans.
- `scripts/verify-harness.sh` (repo has no `Build/Scripts/`; `scripts/` is the existing script location) + `.github/workflows/harness-verify.yml` as thin caller of the shared `script-check.yml` reusable; exit 2 (warnings only) passes.

## Test plan

- `validate-structure.sh`: 1 error / 0 warnings (no root AGENTS.md) → 0 errors / 0 warnings
- `verify-content.sh`: all checks pass (0 warnings)
- `verify-harness.sh`: Level 1 NONE, 8 errors / 2 warnings → Level 2 PARTIAL, 0 errors / 1 warning. The remaining warning ("no git hooks auto-setup detected") is a heuristic gap: captainhook + hook-installer are installed via the `netresearch/typo3-ci-workflows` composer plugin, which the script cannot detect; the reference repo t3x-rte_ckeditor_image carries the same warning.
- `score-agents.sh`: 0/100 (0 files) → 98/100 average over 5 files
- Markdown fences balanced in every added file; every referenced repo path checked for existence relative to its scope directory
