### PR TITLE
ci: state that this extension has no functional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,10 @@ jobs:
     with:
         php-versions: '["8.2","8.3","8.4","8.5"]'
         typo3-versions: '["^13.4"]'
+        # This extension has no functional tests. Without this the shared
+        # workflow runs its functional job, finds no test script, and reports
+        # success — coverage that does not exist. See
+        # netresearch/typo3-ci-workflows#188.
+        run-functional-tests: false
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The functional job runs here today, finds no `ci:test:php:functional` script and no `functional-test-command`, and reports **success** on the strength of `::notice::No functional test script found. Skipping.` — a check that is green because it found nothing to run.

There are no functional test classes in this repository, so `run-functional-tests: false` is simply the true statement.

[typo3-ci-workflows#188](https://github.com/netresearch/typo3-ci-workflows/issues/188) turns that fallback into a failure. This repository is one of exactly two in the fleet that would be made red by it — measured across all 25 active extensions — and this is it saying "no functional tests" beforehand rather than being caught by it.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_