### PR TITLE
ci: add the shared test runner for local suite runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,9 @@ netresearch/nr-sync — TYPO3 v13.4 backend extension (key `nr_sync`) that synch
 | Rector dry-run | `composer ci:test:php:rector` (= `make rector`) |
 | Unit tests | `composer ci:test:php:unit` (= `make test-unit`) |
 | All checks | `composer ci:test` |
+| Any suite in Docker (verified 2026-08-24) | `./Build/Scripts/runTests.sh -s unit\|lint\|phpstan\|rector\|cgl` |
+
+`Build/Scripts/runTests.sh` is the bootstrap stub of `netresearch/typo3-ci-workflows`; the runner comes from the package and is linked into `.build/bin`. It runs the suites in Docker against a chosen PHP version (`-p 8.2`). **Do not run `-s functional` here:** this extension has no functional tests and no functional config, and the runner silently falls back to `Build/phpunit.xml`, so the suite re-runs the 21 unit tests and reports them as functional (netresearch/typo3-ci-workflows#212). `-s lint` uses `php -l` over `Classes Configuration Tests`, not `phplint` with `Build/.phplint.yml` (netresearch/typo3-ci-workflows#217).
 | Harness check | `bash scripts/verify-harness.sh` |
 <!-- AGENTS-GENERATED:END commands -->
 

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+#
+# Bootstrap for the shared TYPO3 extension test runner.
+#
+# Copy this file to Build/Scripts/runTests.sh in an extension. It is NOT the
+# runner: the runner is versioned once in netresearch/typo3-ci-workflows and
+# composer links it to .Build/bin/runTests.sh. This stub exists only because
+# the runner provisions the very environment it lives in, so it cannot be
+# behind a completed `composer install` — the first run on a fresh clone has
+# to create it.
+#
+# Per-extension settings belong in Build/Scripts/runTests.conf, never here.
+# Anything this stub grows beyond handing over is drift; fix the shared runner
+# instead.
+#
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# composer.json says where composer puts binaries. Hardcoding .Build/bin was
+# wrong for nine extensions in this fleet: seven use lowercase .build/bin and
+# two use vendor/bin, and there this stub would not have found the runner at
+# all. The runner detects the same thing for itself; the stub has to do it
+# before the runner exists.
+bin_dir() {
+    local dir=""
+    if type jq >/dev/null 2>&1; then
+        dir="$(jq -r '.config["bin-dir"] // ((.config["vendor-dir"] // "vendor") + "/bin") // empty' composer.json 2>/dev/null)"
+    else
+        dir="$(sed -n 's/.*"bin-dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' composer.json | head -n1)"
+        [[ -n "${dir}" ]] || dir="$(sed -n 's/.*"vendor-dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1\/bin/p' composer.json | head -n1)"
+    fi
+    printf '%s' "${dir:-vendor/bin}"
+}
+
+RUNNER="$(bin_dir)/runTests.sh"
+
+if [[ ! -x "${RUNNER}" ]]; then
+    echo "runTests.sh: ${RUNNER} not found — installing dependencies first." >&2
+    if ! type composer >/dev/null 2>&1; then
+        echo "runTests.sh: composer is not on PATH, cannot bootstrap ${RUNNER}." >&2
+        exit 1
+    fi
+    composer install --no-interaction --no-progress
+fi
+
+if [[ ! -x "${RUNNER}" ]]; then
+    echo "runTests.sh: ${RUNNER} is still missing after composer install." >&2
+    echo "             Is netresearch/typo3-ci-workflows in require-dev?" >&2
+    exit 1
+fi
+
+exec "${RUNNER}" "$@"

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "netresearch/nr-scheduler": "*"
     },
     "require-dev": {
-        "netresearch/typo3-ci-workflows": "^1.1"
+        "netresearch/typo3-ci-workflows": "^1.8.1"
     },
     "extra": {
         "typo3/cms": {


### PR DESCRIPTION
This repo already depends on `netresearch/typo3-ci-workflows` for its CI workflows, but had no local runner — the suites were reachable only through the Composer scripts and the Makefile targets that wrap them, both running against whatever PHP the shell happens to have. This adds the package's bootstrap stub as `Build/Scripts/runTests.sh`, so the same suites can be run locally in Docker against a chosen PHP version.

**The Composer scripts and the Makefile are unchanged.** CI runs exactly as before; the runner is an additional local entry point, not a replacement.

Verified locally against `787bfcd`:

| Suite | Result |
|---|---|
| `-s unit` | Tests: 21, Assertions: 54, exit 0 |
| `-s lint` | exit 0 |
| `-s phpstan` | exit 0 |
| `-s rector` | exit 0 |
| `-s cgl -n` | exit 0 |

Three configs sit at non-standard locations (`Build/phpstan.neon`, `Build/rector.php`, `Build/.php-cs-fixer.dist.php`). The runner finds all three and prints a notice for each on every call, so no `runTests.conf` is needed.

**`-s functional` is deliberately absent from the documented commands.** This extension has no functional tests and no functional config, so the runner falls back to `Build/phpunit.xml` and re-runs the same 21 unit tests under a `Result of functional ... SUCCESS` banner. That is [typo3-ci-workflows#212](https://github.com/netresearch/typo3-ci-workflows/issues/212); `AGENTS.md` names the trap rather than leaving someone to find it.

`-s lint` runs `php -l` over `Classes Configuration Tests`, not `phplint` with `Build/.phplint.yml` — filed as [typo3-ci-workflows#217](https://github.com/netresearch/typo3-ci-workflows/issues/217).

The package requirement moves from `^1.1` to `^1.8.1` for the cgl config detection ([typo3-ci-workflows#204](https://github.com/netresearch/typo3-ci-workflows/issues/204)); without it `-s cgl` would ignore `Build/.php-cs-fixer.dist.php` and rewrite files against php-cs-fixer's defaults.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_